### PR TITLE
fix up cli tests

### DIFF
--- a/cmd/warpforge/main_test.go
+++ b/cmd/warpforge/main_test.go
@@ -171,7 +171,12 @@ func buildExecFn(projPath string) func(args []string, stdin io.Reader, stdout io
 		if err != nil {
 			panic("failed to set WARPFORGE_WAREHOUSE")
 		}
-
+		if args[0] == "cd" {
+			if err := os.Chdir(args[1]); err != nil {
+				return 1, err
+			}
+			return 0, nil
+		}
 		err = makeApp(stdin, stdout, stderr).Run(args)
 		if err != nil {
 			return 1, err

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -428,7 +428,7 @@ cat .warpforge/catalogs/my-catalog/warpsys.org/busybox/_mirrors.json
 	"catalogmirrors.v1": {
 		"byWare": {
 			"tar:4z9DCTxoKkStqXQRwtf9nimpfQQ36dbndDsAPCQgECfbXt3edanUrsVKCjE9TkX2v9": [
-				"file://.warpforge/warehouse/4z9/DCT/4z9DCTxoKkStqXQRwtf9nimpfQQ36dbndDsAPCQgECfbXt3edanUrsVKCjE9TkX2v9"
+				"https://warpsys.s3.amazonaws.com/warehouse/4z9/DCT/4z9DCTxoKkStqXQRwtf9nimpfQQ36dbndDsAPCQgECfbXt3edanUrsVKCjE9TkX2v9"
 			]
 		}
 	}
@@ -489,31 +489,39 @@ cat .warpforge/catalogs/default/github.com/githubtraining/training-manual/_mirro
 
 Test module that uses a catalog input:
 
-[testmark]:# (catalog/then-add/then-bundle/fs/module.wf)
+[testmark]:# (base-workspace/then-bundle/fs/workspace/.warpforge/notrelevant)
+```
+this file creates directories for a local workspace
+```
+
+[testmark]:# (base-workspace/then-bundle/fs/workspace/module.wf)
 ```
 {
 	"name": "bundle-test",
 }
 ```
 
-[testmark]:# (catalog/then-add/then-bundle/fs/plot.wf)
+[testmark]:# (base-workspace/then-bundle/fs/workspace/plot.wf)
 ```
 {
-	"inputs": {
-		"rootfs": "catalog:warpsys.org/busybox:v1.35.0:amd64-static"
-	},
-	"steps": {},
-	"outputs": {}
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:warpsys.org/busybox:v1.35.0:amd64-static"
+		},
+		"steps": {},
+		"outputs": {}
+	}
 }
 ```
 
 
-[testmark]:# (catalog/then-add/then-bundle/sequence)
+[testmark]:# (base-workspace/then-bundle/script)
 ```
+cd workspace
 warpforge -v catalog bundle module.wf
 ```
 
-[testmark]:# (catalog/then-add/then-bundle/stdout)
+[testmark]:# (base-workspace/then-bundle/output)
 ```
 bundled "warpsys.org/busybox:v1.35.0:amd64-static"
 ```
@@ -525,16 +533,16 @@ The `ferk` command rapidly spawns a container in interactive mode. If the direct
 
 Run `ferk` using Busybox as the rootfs and invoke `/bin/echo`.
 
-[testmark]:# (catalog/then-add/then-ferk/sequence)
+[testmark]:# (base-workspace/then-ferk/sequence)
 ```
 warpforge --json --quiet ferk --rootfs catalog:warpsys.org/busybox:v1.35.0:amd64-static --cmd /bin/echo --no-interactive
 ```
 
 Check that `ferk` ran successfully, no outputs are expected.
 
-[testmark]:# (catalog/then-add/then-ferk/stdout)
+[testmark]:# (base-workspace/then-ferk/stdout)
 ```
-{ "runrecord": { "guid": "055a7ca6-4ea8-49d1-8053-e01e05202495", "time": 1648067779, "formulaID": "bafyrgqa3vklfqcqd6pjj6roc6vzny4p2rx4cqnptgo3rgze3qvemajrlpraiutycb2bebfk2lobgcmvaqpdnoip6zsfwooaulqqoraweyln6k", "exitcode": 0, "results": { "out": "ware:tar:-" } } } 
+{ "runrecord": { "guid": "055a7ca6-4ea8-49d1-8053-e01e05202495", "time": 1648067779, "formulaID": "zM5K3V1fXVjExjfVd8d7ByUQ7HP16QAcZcoRd1bh3X4uvms1Xbpb87c1a7WNaw8Hw2B3uF6", "exitcode": 0, "results": { "out": "ware:tar:-" } } } 
 { "plotresults": { "out": "tar:-" } } 
 ```
 
@@ -543,23 +551,23 @@ Check that `ferk` ran successfully, no outputs are expected.
 The `quickstart` command creates a minimal Plot and Module. This requires content from
 the default catalog, which was installed and updated in the previous section.
 
-[testmark]:# (catalog/then-update/then-quickstart/sequence)
+[testmark]:# (base-workspace/then-quickstart/sequence)
 ```
 warpforge --quiet quickstart warpforge.org/my-quickstart-module
 ```
 
-[testmark]:# (catalog/then-update/then-quickstart/stdout)
+[testmark]:# (base-workspace/then-quickstart/output)
 ```
 ```
 
 This "hello world" example can the be run normally.
 
-[testmark]:# (catalog/then-update/then-quickstart/then-run/sequence)
+[testmark]:# (base-workspace/then-quickstart/then-run/sequence)
 ```
 warpforge --json run
 ```
 
-[testmark]:# (catalog/then-update/then-quickstart/then-run/stdout)
+[testmark]:# (base-workspace/then-quickstart/then-run/stdout)
 ```
 { "log": { "Msg": "inputs:" } } 
 { "log": { "Msg": "type = catalog ref = catalog:warpsys.org/busybox:v1.35.0:amd64-static" } } 

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -168,7 +168,7 @@ Because it was successfully checked, the output is nothing:
 Excuting a formula is done with the `warpforge run` command.
 When given a formula file, it knows what to do:
 
-[testmark]:# (runformula/net/sequence)
+[testmark]:# (runformula/tags=net/sequence)
 ```
 warpforge --json --quiet run formula.json
 ```
@@ -176,7 +176,7 @@ warpforge --json --quiet run formula.json
 We'll run this in a filesystem that contains a `formula.json`
 (the same one we used in the check example earlier).
 
-[testmark]:# (runformula/net/fs/formula.json)
+[testmark]:# (runformula/tags=net/fs/formula.json)
 ```
 {
     "formula": {
@@ -210,7 +210,7 @@ We'll run this in a filesystem that contains a `formula.json`
 
 The result of this will be a `RunRecord` object printed to stdout:
 
-[testmark]:# (runformula/net/stdout)
+[testmark]:# (runformula/tags=net/stdout)
 ```
 { "runrecord": { "guid": "389c442f-5343-497e-b74d-d31fd487af53", "time": "22222222222", "formulaID": "zM5K3Zz8R3ioVVWZ6o6GocxPKvubAJfv4iQmDH3GCq9UjtDjHtRWrry4DRoEBPvfUEYFx1D", "exitcode": 0, "results": {} } } 
 ```
@@ -364,21 +364,21 @@ there's only one record in this map.
 
 ## Catalog Operations
 
-[testmark]:# (catalog/fs/.warpforge/root)
+[testmark]:# (catalog/tags=net/fs/.warpforge/root)
 ```
 this file marks the workspace as a root workspace
 ```
 
 ### Initialize a Catalog
 
-[testmark]:# (catalog/sequence)
+[testmark]:# (catalog/tags=net/sequence)
 ```
 warpforge catalog init my-catalog
 ```
 
 ### List Catalogs
 
-[testmark]:# (catalog/then-ls/sequence)
+[testmark]:# (catalog/tags=net/then-ls/sequence)
 ```
 warpforge catalog ls
 ```
@@ -393,20 +393,19 @@ warpforge catalog --name=test generate-html
 ### Add an Item to a Catalog
 
 #### tar
-
-[testmark]:# (catalog/net/then-add-tar/sequence)
+[testmark]:# (catalog/tags=net/then-add-tar/sequence)
 ```
 warpforge catalog --name my-catalog add tar warpsys.org/busybox:v1.35.0:amd64-static https://warpsys.s3.amazonaws.com/warehouse/4z9/DCT/4z9DCTxoKkStqXQRwtf9nimpfQQ36dbndDsAPCQgECfbXt3edanUrsVKCjE9TkX2v9
 ```
 
-[testmark]:# (catalog/net/then-add-tar/then-check/script)
+[testmark]:# (catalog/tags=net/then-add-tar/then-check/script)
 ```
 cat .warpforge/catalogs/my-catalog/warpsys.org/busybox/_module.json
 cat .warpforge/catalogs/my-catalog/warpsys.org/busybox/_releases/v1.35.0.json
 cat .warpforge/catalogs/my-catalog/warpsys.org/busybox/_mirrors.json
 ```
 
-[testmark]:# (catalog/net/then-add-tar/then-check/output)
+[testmark]:# (catalog/tags=net/then-add-tar/then-check/output)
 ```
 {
 	"catalogmodule.v1": {
@@ -437,24 +436,24 @@ cat .warpforge/catalogs/my-catalog/warpsys.org/busybox/_mirrors.json
 
 #### git
 
-[testmark]:# (catalog-git/net/fs/.warpforge/root)
+[testmark]:# (catalog-git/tags=net/fs/.warpforge/root)
 ```
 this file marks the workspace as a root workspace
 ```
 
-[testmark]:# (catalog-git/net/sequence)
+[testmark]:# (catalog-git/tags=net/sequence)
 ```
 warpforge catalog add git github.com/githubtraining/training-manual:v1.0:src https://github.com/githubtraining/training-manual v1.0
 ```
 
-[testmark]:# (catalog-git/net/then-check/script)
+[testmark]:# (catalog-git/tags=net/then-check/script)
 ```
 cat .warpforge/catalogs/default/github.com/githubtraining/training-manual/_module.json
 cat .warpforge/catalogs/default/github.com/githubtraining/training-manual/_releases/v1.0.json
 cat .warpforge/catalogs/default/github.com/githubtraining/training-manual/_mirrors.json
 ```
 
-[testmark]:# (catalog-git/net/then-check/output)
+[testmark]:# (catalog-git/tags=net/then-check/output)
 ```
 {
 	"catalogmodule.v1": {

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -515,7 +515,7 @@ this file creates directories for a local workspace
 ```
 
 
-[testmark]:# (base-workspace/then-bundle/script)
+[testmark]:# (base-workspace/then-bundle/sequence)
 ```
 cd workspace
 warpforge -v catalog bundle module.wf

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e
 	github.com/serum-errors/go-serum v0.7.0
 	github.com/urfave/cli/v2 v2.3.0
-	github.com/warpfork/go-testmark v0.11.0
+	github.com/warpfork/go-testmark v0.11.1-0.20221127032233-5cd7a73883c2
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.9.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
-github.com/warpfork/go-testmark v0.11.0 h1:J6LnV8KpceDvo7spaNU4+DauH2n1x+6RaO2rJrmpQ9U=
-github.com/warpfork/go-testmark v0.11.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
+github.com/warpfork/go-testmark v0.11.1-0.20221127032233-5cd7a73883c2 h1:bXKTlluQYzhX6TWXRFSdYNcWjy5reSiAs4kOBmwavTU=
+github.com/warpfork/go-testmark v0.11.1-0.20221127032233-5cd7a73883c2/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=


### PR DESCRIPTION
Huzzah! :partying_face: 

>With the new additions to testmark, we have a bunch of tests to fix that
weren't actually executing before. This gets us back into a relatively
good state where all the tests pass.

>This change also makes significant changes to how the offline "/net/"
flag works. I.E. Any non-executable children of the parent DirEnt are
copied to the "/net/" DirEnt before execution. This allows a parent with
both online and offline tests to execute and properly pass along
required filesystems, although the parent script/sequence may execute
twice. However, this is _not required_ and a parent of a "/net/"
directory does not need to be executable or have any other children if
the "/net/" DirEnt has executable children. The children copied to the
"/net/" DirEnt must be unique. Any duplicates will be an error.