### PR TITLE
Ferk panic

### DIFF
--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/serum-errors/go-serum"
 	"github.com/urfave/cli/v2"
 
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
@@ -55,7 +56,7 @@ func cmdFerk(c *cli.Context) error {
 		// plot was provided, load from file
 		plot, err = util.PlotFromFile(c.String("plot"))
 		if err != nil {
-			return err
+			return serum.Error(wfapi.CodePlotInvalid, serum.WithMessageTemplate("plot file {{file}} not parsed"), serum.WithCause(err), serum.WithDetail("file", c.String("plot")))
 		}
 	} else {
 		// no plot provided, generate the basic default plot from json template
@@ -76,6 +77,10 @@ func cmdFerk(c *cli.Context) error {
 			}
 			plot.Inputs.Values["rootfs"] = rootfs
 		}
+	}
+
+	if _, exists := plot.Steps.Values["ferk"]; !exists {
+		return wfapi.ErrorPlotInvalid(`requires a step named "ferk"`)
 	}
 
 	// set command to execute

--- a/cmd/warpforge/main_test.go
+++ b/cmd/warpforge/main_test.go
@@ -70,6 +70,11 @@ func testFile(t *testing.T, fileName string, workDir *string) {
 
 	doc.BuildDirIndex()
 	patches := testmark.PatchAccumulator{}
+	defer func() {
+		if *testmark.Regen {
+			patches.WriteFileWithPatches(doc, fileName)
+		}
+	}()
 	for _, dir := range doc.DirEnt.ChildrenList {
 		testName := dir.Name
 		testDir := dir

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -545,6 +545,50 @@ Check that `ferk` ran successfully, no outputs are expected.
 { "plotresults": { "out": "tar:-" } } 
 ```
 
+[testmark]:# (base-workspace/then-ferk-with-plot/fs/plot.wf)
+```
+{
+  "plot.v1": {
+    "inputs": {
+      "rootfs": "catalog:warpsys.org/busybox:v1.35.0:amd64-static"
+    },
+    "steps": {
+      "ferk": {
+        "protoformula": {
+          "inputs": {
+            "/": "pipe::rootfs"
+          },
+          "action": {
+            "script": {
+              "interpreter": "/bin/bash",
+              "contents": [
+                "echo 'APT::Sandbox::User \"root\";' > /etc/apt/apt.conf.d/01ferk",
+                "echo 'Dir::Log::Terminal \"\";' >> /etc/apt/apt.conf.d/01ferk",
+                "/bin/bash"
+              ],
+              "network": true
+            }
+          },
+          "outputs": {}
+        }
+      }
+    },
+    "outputs": {}
+  }
+}
+```
+
+[testmark]:# (base-workspace/then-ferk-with-plot/sequence)
+```
+warpforge --json --quiet ferk --plot ./plot.wf --cmd /bin/echo --no-interactive
+```
+
+[testmark]:# (base-workspace/then-ferk-with-plot/stdout)
+```
+{ "runrecord": { "guid": "5217c90a-ac1e-413a-8d55-3eac762d81e1", "time": 1669691979, "formulaID": "zM5K3YWRYqSgvxgMkAA9KbzPpqtRPbufF2z397SNJ1mKTkp9SpmxA8jD3YmTPu3EWvijMSv", "exitcode": 0, "results": {} } } 
+{ "plotresults": {} } 
+```
+
 # Quickstart
 
 The `quickstart` command creates a minimal Plot and Module. This requires content from

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/warptools/warpforge
 
-//replace github.com/ipld/go-ipld-prime => /home/eric/git/go-ipld-prime
-
 go 1.18
 
 require (
@@ -11,7 +9,7 @@ require (
 	github.com/frankban/quicktest v1.14.3
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/uuid v1.3.0
-	github.com/ipfs/go-cid v0.2.0
+	github.com/ipfs/go-cid v0.3.2
 	github.com/ipld/go-datalark v0.4.0
 	github.com/ipld/go-ipld-prime v0.17.0
 	github.com/opencontainers/runtime-spec v1.0.2
@@ -41,7 +39,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -59,7 +57,7 @@ require (
 	github.com/multiformats/go-base32 v0.0.4 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multihash v0.2.0 // indirect
+	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -179,8 +179,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/ipfs/go-cid v0.2.0 h1:01JTiihFq9en9Vz0lc0VDWvZe/uBonGpzo4THP0vcQ0=
-github.com/ipfs/go-cid v0.2.0/go.mod h1:P+HXFDF4CVhaVayiEb4wkAy7zBHxBwsJyt0Y5U6MLro=
+github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
+github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/ipld/go-datalark v0.4.0 h1:Q5GMvmrdUoB4DJbt4A8AcegK3l/1Fq7f7TCt+b4Gugg=
 github.com/ipld/go-datalark v0.4.0/go.mod h1:k4H9UQldzJDxb174CWt2okuOBjDJHnFHiYF9uxK3Haw=
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
@@ -228,8 +228,8 @@ github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoR
 github.com/multiformats/go-multibase v0.1.1 h1:3ASCDsuLX8+j4kx58qnJ4YFq/JWTJpCyDW27ztsVTOI=
 github.com/multiformats/go-multibase v0.1.1/go.mod h1:ZEjHE+IsUrgp5mhlEAYjMtZwK1k4haNkcaPg9aoe1a8=
 github.com/multiformats/go-multicodec v0.5.0 h1:EgU6cBe/D7WRwQb1KmnBvU7lrcFGMggZVTPtOW9dDHs=
-github.com/multiformats/go-multihash v0.2.0 h1:oytJb9ZA1OUW0r0f9ea18GiaPOo4SXyc7p2movyUuo4=
-github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
+github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d16Vve9l108=
+github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -12,6 +12,8 @@ const (
 	errCodeAlreadyExists = "warpforge-error-already-exists"
 	CodeSyscall          = "warpforge-error-syscall"
 	CodePlotExecution    = "warpforge-error-plot-execution-failed"
+	CodeSerialization    = "warpforge-error-serialization"
+	CodePlotInvalid      = "warpforge-error-plot-invalid"
 )
 
 // Error is a grouping interface for wfapi errors.
@@ -198,7 +200,7 @@ func ErrorIo(context string, path string, cause error) Error {
 //    - warpforge-error-serialization --
 func ErrorSerialization(context string, cause error) Error {
 	return &ErrorVal{
-		CodeString: "warpforge-error-serialization",
+		CodeString: CodeSerialization,
 		Message:    fmt.Sprintf("serialization error: %s: %s", context, cause),
 		Details: [][2]string{
 			{"context", context},
@@ -290,7 +292,7 @@ func ErrorFormulaExecutionFailed(cause error) Error {
 //    - warpforge-error-plot-invalid --
 func ErrorPlotInvalid(reason string) Error {
 	return &ErrorVal{
-		CodeString: "warpforge-error-plot-invalid",
+		CodeString: CodePlotInvalid,
 		Message:    fmt.Sprintf("invalid plot: %s", reason),
 		Details: [][2]string{
 			{"reason", reason},


### PR DESCRIPTION
Relatively minor fix. I will however take a moment to complain about ipld error output.
>execution failed: error from ExecFn is "warpforge-error-plot-invalid: plot file ./plot.wf not parsed: caused by: warpforge-error-serialization: serialization error: unable to deserialize plot: bindnode TODO: len mismatch"

Particularly that last bit: `bindnode TODO: len mismatch` is where the actual "which part of this json is bad" error should be sitting. Playing around with the ipld library, I got it to emit `could not assign string \"pipe:rootfs\": bindnode TODO: len mismatch` which is significantly more useful (oh look I forgot a colon). I'm not sure if that kind of thing is generalizable in any way.

Oh and this is dependent on #39. <- merged and rebased.