### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,13 +6,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - name: Clone Serum Analyzer
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: serum-errors/go-serum-analyzer
         ref: master
@@ -27,9 +27,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - run: mkdir /tmp/bundle
@@ -39,7 +39,7 @@ jobs:
     - name: Create release tarball
       run: tar -C /tmp/bundle/ -czvf warpforge.tgz .
     - name: Archive release tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: warpforge.tgz
         path: warpforge.tgz


### PR DESCRIPTION
We've been getting a deprecation warning on github actions. This will update the v2 actions to v3. It doesn't appear that any other changes are required.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-go@v2, actions/upload-artifact@v2
