### PR TITLE
Fix duplicate GHA actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,11 @@
 name: warpforge
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,6 @@
 name: warpforge
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
We previously did two builds on every push to a PR. This performs builds on pushes to PRs, and also on pushes to main/master branch.