### PR TITLE
Sketch of possible API for local workspace situation reporting.

### DIFF
--- a/pkg/workspaceapi/api.go
+++ b/pkg/workspaceapi/api.go
@@ -1,0 +1,53 @@
+package workspaceapi
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/warptools/warpforge/wfapi"
+
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	schemadmt "github.com/ipld/go-ipld-prime/schema/dmt"
+	schemadsl "github.com/ipld/go-ipld-prime/schema/dsl"
+)
+
+// embed the wfapi ipld schema from file
+//go:embed wfwsapi.ipldsch
+var schFs embed.FS
+
+var SchemaDMT, TypeSystem = func() (*schemadmt.Schema, *schema.TypeSystem) {
+	r, err := schFs.Open("wfwsapi.ipldsch")
+	if err != nil {
+		panic(fmt.Sprintf("failed to open embedded wfwsapi.ipldsch: %s", err))
+	}
+	schemaDmt, err := schemadsl.Parse("wfwsapi.ipldsch", r)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse api schema: %s", err))
+	}
+	schemaDmt = concat(wfapi.SchemaDMT, schemaDmt)
+
+	ts := new(schema.TypeSystem)
+	ts.Init()
+	if err := schemadmt.Compile(ts, schemaDmt); err != nil {
+		panic(fmt.Sprintf("failed to compile api schema: %s", err))
+	}
+	return schemaDmt, ts
+}()
+
+// concat returns a new schemadmt that's got the types from both.
+//
+// This function could probably be hoisted upstream.
+func concat(a, b *schemadmt.Schema) *schemadmt.Schema {
+	nb := schemadmt.Type.Schema.NewBuilder()
+	if err := datamodel.Copy(bindnode.Wrap(a, schemadmt.Type.Schema.Type()), nb); err != nil {
+		panic(err)
+	}
+	if err := datamodel.Copy(bindnode.Wrap(b, schemadmt.Type.Schema.Type()), nb); err != nil {
+		panic(err)
+	}
+	return bindnode.Unwrap(nb.Build()).(*schemadmt.Schema)
+}

--- a/pkg/workspaceapi/api_test.go
+++ b/pkg/workspaceapi/api_test.go
@@ -1,0 +1,4 @@
+package workspaceapi
+
+// file exists just to make sure some test files exist, and thus package init is exercised, and thus we test it doesn't panic.
+// drop the above comment when we get more actual test content.

--- a/pkg/workspaceapi/wfwsapi.ipldsch
+++ b/pkg/workspaceapi/wfwsapi.ipldsch
@@ -1,0 +1,73 @@
+## API types for the Warpforge workspace API.
+##
+## This API is concerned with a local workspace.
+## It has operations like asking about the state of modules -- and in doing so,
+## it freely discusses local filesystem paths,
+## and sometimes even "most recent" operations,
+## which are not conversations that can be generalized beyond a single-user/local workspace.
+##
+## This is a demo prototype and entirely subject to change.
+##
+
+## This file builds upon the types in the '../wfapi/wfapi.ipldsch' schema.
+## You'll have to parse both.
+
+## There's no use of the "capsule" types convention for versioning here.
+## This is a local-only protocol; there's no real sense in versioning it,
+## because both parties speaking it are expected to come from the same build.
+
+type Ping struct {
+	callID String
+}
+
+type PingAck struct {
+	callID String
+}
+
+type ModuleStatusQuery struct {
+	## Path to module within the workspace is the primary identifier.
+	## (This saves the workspace daemon from having to find all modules in advance and cache a name->path lookup.)
+	path String
+
+	## Mappings from some inputs (usually, ingests) to a resolved WareID can be specified.
+	## Using this enables stories like "replace 'ingest:git:.:HEAD' with 'ware:git:071283c'".
+	## (This is useful for e.g. the CI usecase,
+	## where the `wf spark` command wants to ask if we've successfully built a plot for some specific git hash.)
+	inputReplacements optional {PlotInput:WareID}
+
+	## Set the interest level to "query" if you only want to ask about existing knowledge.
+	## Set it to something higher if you want the workspace daemon to go discover something if it's not already known.
+	interestLevel ModuleInterestLevel
+}
+
+type ModuleInterestLevel enum {
+	| Query ("query") # Means: just ask; don't run something if you wouldn't have already.
+	| Run ("run")     # Means: still answer with what you know now, but also please run this if you haven't already.
+	# Consider: maybe an option that means "eval now please, and also add this to a set of things polled (for the next hour or so, with some decay function)"?  User story: "wf spark" can be both a display tool and an unobtrusive attention indicator.
+}
+
+type ModuleStatusAnswer struct {
+	## Matches what was submitted in ModuleStatusQuery, in case you have more than one outstanding request.
+	path String
+	# FIXME: since we have other fields like inputReplacements, this should probably have seq numbers or some other id.
+
+	status ModuleStatus
+}
+
+type ModuleStatus union {
+	| ModuleStatus_NoInfo "noinfo"
+	| ModuleStatus_Queuing "queuing"
+	| ModuleStatus_InProgress "inprogress"
+	| ModuleStatus_FailedProvisioning "failed_provisioning"
+	| ModuleStatus_ExecutedSuccess "executed_success"
+	| ModuleStatus_ExecutedFailed "executed_failed"
+} representation keyed
+
+# TODO most of the below surely deserve some more body content; wip.
+
+type ModuleStatus_NoInfo struct {}
+type ModuleStatus_Queuing struct {}
+type ModuleStatus_InProgress struct {}
+type ModuleStatus_FailedProvisioning struct {}
+type ModuleStatus_ExecutedSuccess struct {}
+type ModuleStatus_ExecutedFailed struct {}


### PR DESCRIPTION
This commit is foremost an outline and proof-of-concept that we can split definitions of our schema into multiple files, and reuse the main warpforge API schema types in this second, superset schema.  And yep: that works.  (I did something a tad hacky to achieve it.  I'll try to push at least some of that towards upstream.  It's mild, though.)

The actual message types declared in this diff are a sketch only, and not firmly committed to.