### PR TITLE
Fixes partial bundle error

### DIFF
--- a/cmd/warpforge/internal/util/util.go
+++ b/cmd/warpforge/internal/util/util.go
@@ -136,7 +136,7 @@ func ModuleFromFile(filename string) (wfapi.Module, error) {
 //    - warpforge-error-catalog-parse --
 //    - warpforge-error-git --
 //    - warpforge-error-io -- when the module or plot files cannot be read or cannot change directory.
-//    - warpforge-error-missing-catalog-entry --
+//    - warpforge-error-catalog-missing-entry --
 //    - warpforge-error-module-invalid -- when the module data is invalid
 //    - warpforge-error-plot-execution-failed --
 //    - warpforge-error-plot-invalid -- when the plot data is invalid

--- a/pkg/plotexec/plot_exec.go
+++ b/pkg/plotexec/plot_exec.go
@@ -57,7 +57,7 @@ func (m pipeMap) lookup(stepName wfapi.StepName, label wfapi.LocalLabel) (*wfapi
 // Errors:
 //
 //    - warpforge-error-plot-invalid -- when the provided plot input is invalid
-//    - warpforge-error-missing-catalog-entry -- when a referenced catalog reference cannot be found
+//    - warpforge-error-catalog-missing-entry -- when a referenced catalog reference cannot be found
 //    - warpforge-error-git -- when a git related error occurs during a git ingest
 //    - warpforge-error-io -- when an IO error occurs during conversion
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
@@ -98,7 +98,7 @@ func plotInputToFormulaInput(ctx context.Context,
 // Errors:
 //
 //    - warpforge-error-plot-invalid -- when the provided plot input is invalid
-//    - warpforge-error-missing-catalog-entry -- when a referenced catalog reference cannot be found
+//    - warpforge-error-catalog-missing-entry -- when a referenced catalog reference cannot be found
 //    - warpforge-error-git -- when a git related error occurs during a git ingest
 //    - warpforge-error-io -- when an IO error occurs during conversion
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
@@ -324,7 +324,7 @@ func plotInputToFormulaInputSimple(ctx context.Context,
 //    - warpforge-error-formula-invalid -- when an invalid formula is provided
 //    - warpforge-error-git -- when an error handing a git ingest occurs
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
-//    - warpforge-error-missing-catalog-entry -- when a referenced catalog entry cannot be found
+//    - warpforge-error-catalog-missing-entry -- when a referenced catalog entry cannot be found
 //    - warpforge-error-plot-invalid -- when the plot contains invalid data
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when a replay fails
@@ -384,7 +384,7 @@ func execProtoformula(ctx context.Context,
 // Errors:
 //
 //    - warpforge-error-plot-invalid -- when the provided plot input is invalid
-//    - warpforge-error-missing-catalog-entry -- when a referenced catalog reference cannot be found
+//    - warpforge-error-catalog-missing-entry -- when a referenced catalog reference cannot be found
 //    - warpforge-error-git -- when a git related error occurs during a git ingest
 //    - warpforge-error-io -- when an IO error occurs during conversion
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
@@ -513,7 +513,7 @@ func execPlot(ctx context.Context, wsSet workspace.WorkspaceSet, plot wfapi.Plot
 // Errors:
 //
 //    - warpforge-error-plot-invalid -- when the provided plot input is invalid
-//    - warpforge-error-missing-catalog-entry -- when a referenced catalog reference cannot be found
+//    - warpforge-error-catalog-missing-entry -- when a referenced catalog reference cannot be found
 //    - warpforge-error-git -- when a git related error occurs during a git ingest
 //    - warpforge-error-io -- when an IO error occurs during conversion
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -336,7 +336,7 @@ func (c *Config) Run(ctx context.Context) error {
 //    - warpforge-error-datatoonew -- when module or plot has an unrecognized version number
 //    - warpforge-error-git --
 //    - warpforge-error-io -- when the module or plot files cannot be read or cannot change directory.
-//    - warpforge-error-missing-catalog-entry --
+//    - warpforge-error-catalog-missing-entry --
 //    - warpforge-error-plot-execution-failed --
 //    - warpforge-error-plot-invalid -- when the plot data is invalid
 //    - warpforge-error-plot-step-failed --

--- a/pkg/workspace/catalog.go
+++ b/pkg/workspace/catalog.go
@@ -203,7 +203,7 @@ func (cat *Catalog) GetRelease(ref wfapi.CatalogRef) (*wfapi.CatalogRelease, err
 //     - warpforge-error-io -- when reading of lineage or mirror files fails
 //     - warpforge-error-catalog-parse -- when ipld parsing of lineage or mirror files fails
 //     - warpforge-error-catalog-invalid -- when catalog files are not found
-//     - warpforge-error-missing-catalog-entry -- when catalog item is not found
+//     - warpforge-error-catalog-missing-entry -- when catalog item is not found
 func (cat *Catalog) GetWare(ref wfapi.CatalogRef) (*wfapi.WareID, *wfapi.WarehouseAddr, error) {
 	release, err := cat.GetRelease(ref)
 	if err != nil {

--- a/pkg/workspace/catalog.go
+++ b/pkg/workspace/catalog.go
@@ -202,7 +202,8 @@ func (cat *Catalog) GetRelease(ref wfapi.CatalogRef) (*wfapi.CatalogRelease, err
 //
 //     - warpforge-error-io -- when reading of lineage or mirror files fails
 //     - warpforge-error-catalog-parse -- when ipld parsing of lineage or mirror files fails
-//     - warpforge-error-catalog-invalid -- when catalog files or entries are not found
+//     - warpforge-error-catalog-invalid -- when catalog files are not found
+//     - warpforge-error-missing-catalog-entry -- when catalog item is not found
 func (cat *Catalog) GetWare(ref wfapi.CatalogRef) (*wfapi.WareID, *wfapi.WarehouseAddr, error) {
 	release, err := cat.GetRelease(ref)
 	if err != nil {
@@ -216,9 +217,8 @@ func (cat *Catalog) GetWare(ref wfapi.CatalogRef) (*wfapi.WareID, *wfapi.Warehou
 	// valid release found found, now try find the item
 	wareId, itemFound := release.Items.Values[ref.ItemName]
 	if !itemFound {
-		return nil, nil, wfapi.ErrorCatalogInvalid(
-			cat.releaseFilePath(ref),
-			fmt.Sprintf("release %q does not contain the requested item %q", release.ReleaseName, ref.ItemName))
+		// it doesn't make sense to check for a replay when we don't have an ID
+		return nil, nil, wfapi.ErrorMissingCatalogEntry(ref, false)
 	}
 
 	// item found, check for a matching mirror

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -231,6 +231,7 @@ func (ws *Workspace) ListCatalogs() ([]string, error) {
 //     - warpforge-error-io -- when reading of lineage or mirror files fails
 //     - warpforge-error-catalog-parse -- when ipld parsing of lineage or mirror files fails
 //     - warpforge-error-catalog-invalid -- when ipld parsing of lineage or mirror files fails
+//     - warpforge-error-missing-catalog-entry -- when catalog item is missing
 func (ws *Workspace) GetCatalogWare(ref wfapi.CatalogRef) (*wfapi.WareID, *wfapi.WarehouseAddr, error) {
 	// list the catalogs within the "catalogs" subdirectory
 	cats, err := ws.ListCatalogs()

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -231,7 +231,7 @@ func (ws *Workspace) ListCatalogs() ([]string, error) {
 //     - warpforge-error-io -- when reading of lineage or mirror files fails
 //     - warpforge-error-catalog-parse -- when ipld parsing of lineage or mirror files fails
 //     - warpforge-error-catalog-invalid -- when ipld parsing of lineage or mirror files fails
-//     - warpforge-error-missing-catalog-entry -- when catalog item is missing
+//     - warpforge-error-catalog-missing-entry -- when catalog item is missing
 func (ws *Workspace) GetCatalogWare(ref wfapi.CatalogRef) (*wfapi.WareID, *wfapi.WarehouseAddr, error) {
 	// list the catalogs within the "catalogs" subdirectory
 	cats, err := ws.ListCatalogs()

--- a/pkg/workspace/workspace_set.go
+++ b/pkg/workspace/workspace_set.go
@@ -43,7 +43,7 @@ func (wsSet WorkspaceSet) GetCatalogWare(ref wfapi.CatalogRef) (*wfapi.WareID, *
 			if serum.Code(err) == wfapi.ECodeCatalogMissingEntry {
 				continue
 			}
-			// Error Codes -= warpforge-error-missing-catalog-entry
+			// Error Codes -= warpforge-error-catalog-missing-entry
 			return nil, nil, err
 		}
 		if wareId != nil {
@@ -87,7 +87,7 @@ func (wsSet WorkspaceSet) GetCatalogReplay(ref wfapi.CatalogRef) (*wfapi.Plot, e
 //
 //    - warpforge-error-catalog-invalid -- a catalog in this workspace set is invalid
 //    - warpforge-error-catalog-parse -- a catalog in this workspace set can't be parsed
-//    - warpforge-error-missing-catalog-entry -- a dependency can't be found
+//    - warpforge-error-catalog-missing-entry -- a dependency can't be found
 //    - warpforge-error-catalog-name -- honestly, shouldn't happen
 //    - warpforge-error-workspace -- workspace stack missing a non-root workspace
 //    - warpforge-error-io -- reading/writing catalog fails

--- a/pkg/workspace/workspace_set.go
+++ b/pkg/workspace/workspace_set.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/serum-errors/go-serum"
+
 	"github.com/warptools/warpforge/pkg/logging"
 	"github.com/warptools/warpforge/wfapi"
 )
@@ -38,6 +40,10 @@ func (wsSet WorkspaceSet) GetCatalogWare(ref wfapi.CatalogRef) (*wfapi.WareID, *
 	for _, ws := range wsSet {
 		wareId, wareAddr, err := ws.GetCatalogWare(ref)
 		if err != nil {
+			if serum.Code(err) == wfapi.ECodeCatalogMissingEntry {
+				continue
+			}
+			// Error Codes -= warpforge-error-missing-catalog-entry
 			return nil, nil, err
 		}
 		if wareId != nil {

--- a/wfapi/catalog.go
+++ b/wfapi/catalog.go
@@ -85,7 +85,7 @@ func (rel *CatalogRelease) Cid() CatalogReleaseCID {
 
 	// compute CID of parsed release data
 	lsys := cidlink.DefaultLinkSystem()
-	lnk, errRaw := lsys.ComputeLink(cidlink.LinkPrototype{cid.Prefix{
+	lnk, errRaw := lsys.ComputeLink(cidlink.LinkPrototype{Prefix: cid.Prefix{
 		Version:  1,    // Usually '1'.
 		Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
 		MhType:   0x20, // 0x20 means "sha2-384" -- See the multicodecs table: https://github.com/multiformats/multicodec/

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -46,6 +46,23 @@ const (
 	ECodeWorkspace     = "warpforge-error-workspace"
 )
 
+// IsCode reports whether any error in err's chain matches the given code string.
+//
+// The chain consists of err itself followed by the sequence of errors obtained
+// by repeatedly calling serum.Cause which is similar to calling Unwrap.
+//
+// An error is considered to match the code string if the result of
+// serum.Code(err) is equal to the code string.
+func IsCode(err error, code string) bool {
+	for err != nil {
+		if serum.Code(err) == code {
+			return true
+		}
+		err = serum.Cause(err)
+	}
+	return false
+}
+
 // TerminalError emits an error on stdout as json, and halts immediately.
 // In most cases, you should not use this method, and there will be a better place to send errors
 // that will be more guaranteed to fit any protocols and scripts better;

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -14,7 +14,7 @@ const (
 	// Prefer to use a more specific error code or specify _what_ is missing.
 	ECodeAlreadyExists          = "warpforge-error-already-exists"
 	ECodeCatalogInvalid         = "warpforge-error-catalog-invalid"
-	ECodeCatalogMissingEntry    = "warpforge-error-missing-catalog-entry"
+	ECodeCatalogMissingEntry    = "warpforge-error-catalog-missing-entry"
 	ECodeCatalogName            = "warpforge-error-catalog-name"
 	ECodeCatalogParse           = "warpforge-error-catalog-parse"
 	ECodeDataTooNew             = "warpforge-error-datatoonew"
@@ -237,7 +237,7 @@ func ErrorModuleInvalid(reason string) error {
 //
 // Errors:
 //
-//    - warpforge-error-missing-catalog-entry --
+//    - warpforge-error-catalog-missing-entry --
 func ErrorMissingCatalogEntry(ref CatalogRef, replayAvailable bool) error {
 	var msg string
 	var available string

--- a/wfapi/plot.go
+++ b/wfapi/plot.go
@@ -36,7 +36,7 @@ func (plot *Plot) Cid() PlotCID {
 
 	// compute CID of parsed release data
 	lsys := cidlink.DefaultLinkSystem()
-	lnk, errRaw := lsys.ComputeLink(cidlink.LinkPrototype{cid.Prefix{
+	lnk, errRaw := lsys.ComputeLink(cidlink.LinkPrototype{Prefix: cid.Prefix{
 		Version:  1,    // Usually '1'.
 		Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
 		MhType:   0x20, // 0x20 means "sha2-384" -- See the multicodecs table: https://github.com/multiformats/multicodec/


### PR DESCRIPTION
Bundling catalogs with multiple items from a release would error on the second item because warpforge would be looking in the local workspace version of that release which would only contain the first item. This change allows continuing up the workspace stack to find the item.