### PR TITLE
Change min.warpforge.io catalog to warpsys.org

### DIFF
--- a/cmd/warpforge/internal/util/plot_templates.go
+++ b/cmd/warpforge/internal/util/plot_templates.go
@@ -41,7 +41,7 @@ const DefaultPlotJson = `
 const FerkPlotTemplate = `
 {
     "inputs": {
-        "rootfs": "catalog:min.warpforge.io/debian/rootfs:bullseye-1646092800:amd64"
+        "rootfs": "catalog:warpsys.org/bootstrap/debian:bullseye-1646092800:amd64"
     },
     "steps": {
         "ferk": {


### PR DESCRIPTION
We used to have a "min catalog" which contained Debian. I've archived it as read-only since we're now defaulting to warpsys everywhere. 

This removes the only remaining reference to `min.warpforge.io` which was used in ferk, and updates it to use the warpsys catalog.