### PR TITLE
Add validation rules to module names

### DIFF
--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -20,6 +20,7 @@ import (
 	"github.com/warptools/warpforge/cmd/warpforge/internal/catalog"
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
 	"github.com/warptools/warpforge/pkg/cataloghtml"
+	"github.com/warptools/warpforge/pkg/dab"
 	"github.com/warptools/warpforge/pkg/plotexec"
 	"github.com/warptools/warpforge/pkg/tracing"
 	"github.com/warptools/warpforge/wfapi"
@@ -364,7 +365,7 @@ func cmdCatalogBundle(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get pwd: %s", err)
 	}
-	plot, err := util.PlotFromFile(filepath.Join(pwd, util.PlotFilename))
+	plot, err := util.PlotFromFile(filepath.Join(pwd, dab.MagicFilename_Plot))
 	if err != nil {
 		return err
 	}
@@ -469,8 +470,9 @@ func cmdCatalogRelease(c *cli.Context) error {
 		}
 	}
 
+	fsys := os.DirFS("/")
 	// get the module, release, and item values (in format `module:release:item`)
-	module, err := util.ModuleFromFile("module.wf")
+	module, err := dab.ModuleFromFile(fsys, dab.MagicFilename_Module)
 	if err != nil {
 		return err
 	}
@@ -478,7 +480,7 @@ func cmdCatalogRelease(c *cli.Context) error {
 	releaseName := c.Args().Get(0)
 
 	fmt.Printf("building replay for module = %q, release = %q, executing plot...\n", module.Name, releaseName)
-	plot, err := util.PlotFromFile(util.PlotFilename)
+	plot, err := util.PlotFromFile(dab.MagicFilename_Plot)
 	if err != nil {
 		return err
 	}

--- a/cmd/warpforge/check.go
+++ b/cmd/warpforge/check.go
@@ -3,13 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/urfave/cli/v2"
 
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
+	"github.com/warptools/warpforge/pkg/dab"
 	"github.com/warptools/warpforge/pkg/plotexec"
 	"github.com/warptools/warpforge/wfapi"
 )
@@ -24,8 +28,8 @@ var checkCmdDef = cli.Command{
 	),
 }
 
-func checkModule(fileName string) (*ipld.Node, error) {
-	f, err := ioutil.ReadFile(fileName)
+func checkModule(fsys fs.FS, fileName string) (*ipld.Node, error) {
+	f, err := fs.ReadFile(fsys, fileName)
 	if err != nil {
 		return nil, wfapi.ErrorIo("cannot read module file", fileName, err)
 	}
@@ -35,32 +39,39 @@ func checkModule(fileName string) (*ipld.Node, error) {
 	if err != nil {
 		return nil, wfapi.ErrorSerialization("cannot deserialize module", err)
 	}
+
+	if err := dab.ValidateModuleName(moduleCapsule.Module.Name); err != nil {
+		return nil, err
+	}
+
 	return &n, nil
 }
 
-func checkPlot(ctx context.Context, fileName string) (*ipld.Node, error) {
-	f, err := ioutil.ReadFile(fileName)
+func checkPlot(ctx context.Context, fsys fs.FS, fileName string) (*ipld.Node, error) {
+	f, err := fs.ReadFile(fsys, fileName)
 	if err != nil {
 		return nil, wfapi.ErrorIo("cannot read plot file", fileName, err)
 	}
 
 	// parse the Plot
-	plot := wfapi.Plot{}
-	n, err := ipld.Unmarshal([]byte(f), json.Decode, &plot, wfapi.TypeSystem.TypeByName("Plot"))
+	plotCapsule := wfapi.PlotCapsule{}
+	n, err := ipld.Unmarshal([]byte(f), json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 	if err != nil {
 		return nil, wfapi.ErrorSerialization("cannot deserialize plot", err)
 	}
-
+	if plotCapsule.Plot == nil {
+		return nil, wfapi.ErrorPlotInvalid("missing Plot")
+	}
 	// ensure Plot order can be resolved
-	if _, err := plotexec.OrderSteps(ctx, plot); err != nil {
+	if _, err := plotexec.OrderSteps(ctx, *plotCapsule.Plot); err != nil {
 		return &n, err
 	}
 
 	return &n, nil
 }
 
-func checkFormula(fileName string) (*ipld.Node, error) {
-	f, err := ioutil.ReadFile(fileName)
+func checkFormula(fsys fs.FS, fileName string) (*ipld.Node, error) {
+	f, err := fs.ReadFile(fsys, fileName)
 	if err != nil {
 		return nil, wfapi.ErrorIo("cannot read formula file", fileName, err)
 	}
@@ -78,34 +89,43 @@ func cmdCheck(c *cli.Context) error {
 		return fmt.Errorf("no input files provided")
 	}
 	ctx := c.Context
-
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 	for _, filename := range c.Args().Slice() {
-		t, err := util.GetFileType(filename)
+		t, err := dab.GetFileType(filename)
 		if err != nil {
 			return err
 		}
 
+		fsys := os.DirFS(pwd)
+		if strings.HasPrefix(filename, string(filepath.Separator)) {
+			fsys = os.DirFS("/")
+			filename = filename[1:]
+		}
+
 		var n *ipld.Node
 		switch t {
-		case "formula":
-			n, err = checkFormula(filename)
+		case dab.FileType_Formula:
+			n, err = checkFormula(fsys, filename)
 			if err != nil {
 				return err
 			}
 
-		case "plot":
-			n, err = checkPlot(ctx, filename)
+		case dab.FileType_Plot:
+			n, err = checkPlot(ctx, fsys, filename)
 			if err != nil {
 				return err
 			}
-		case "module":
-			n, err = checkModule(filename)
+		case dab.FileType_Module:
+			n, err = checkModule(fsys, filename)
 			if err != nil {
 				return err
 			}
 		default:
 			if c.Bool("verbose") {
-				fmt.Fprintf(c.App.ErrWriter, "ignoring unrecoginzed file: %q\n", filename)
+				fmt.Fprintf(c.App.ErrWriter, "ignoring unrecognized file: %q\n", filename)
 			}
 			continue
 		}

--- a/cmd/warpforge/check.go
+++ b/cmd/warpforge/check.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/serum-errors/go-serum"
 	"github.com/urfave/cli/v2"
 
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
@@ -84,14 +85,25 @@ func checkFormula(fsys fs.FS, fileName string) (*ipld.Node, error) {
 	return &n, nil
 }
 
+// Errors:
+//
+//   - warpforge-error-invalid --
+//   - warpforge-error-io -- unable to get working directory
+//   - warpforge-error-io -- unable to read files
+//   - warpforge-error-module-invalid -- module data is invalid
+//   - warpforge-error-plot-invalid -- plot data is invalid
+//   - warpforge-error-serialization -- unable to parse files
+//   - warpforge-error-invalid-argument -- cli argument is invalid
 func cmdCheck(c *cli.Context) error {
 	if !c.Args().Present() {
-		return fmt.Errorf("no input files provided")
+		return serum.Error(wfapi.ECodeArgument,
+			serum.WithMessageLiteral("no input files provided"),
+		)
 	}
 	ctx := c.Context
 	pwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return serum.Errorf(wfapi.ECodeIo, "unable to get workding directory: %w", err)
 	}
 	for _, filename := range c.Args().Slice() {
 		t, err := dab.GetFileType(filename)

--- a/cmd/warpforge/quickstart.go
+++ b/cmd/warpforge/quickstart.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
+	"github.com/warptools/warpforge/pkg/dab"
 	"github.com/warptools/warpforge/wfapi"
 )
 
@@ -32,8 +33,8 @@ func createQuickstartFiles(moduleName string) error {
 	if err != nil {
 		return wfapi.ErrorSerialization("failed to serialize module", err)
 	}
-	if err = os.WriteFile(util.ModuleFilename, moduleSerial, 0644); err != nil {
-		return wfapi.ErrorIo("failed to write module file", util.ModuleFilename, err)
+	if err = os.WriteFile(dab.MagicFilename_Module, moduleSerial, 0644); err != nil {
+		return wfapi.ErrorIo("failed to write module file", dab.MagicFilename_Module, err)
 	}
 	plotCapsule := wfapi.PlotCapsule{}
 	_, err = ipld.Unmarshal([]byte(util.DefaultPlotJson), json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
@@ -45,8 +46,8 @@ func createQuickstartFiles(moduleName string) error {
 	if err != nil {
 		return wfapi.ErrorSerialization("failed to serialize plot", err)
 	}
-	if err := os.WriteFile(util.PlotFilename, plotSerial, 0644); err != nil {
-		return wfapi.ErrorIo("failed to write plot file", util.PlotFilename, err)
+	if err := os.WriteFile(dab.MagicFilename_Plot, plotSerial, 0644); err != nil {
+		return wfapi.ErrorIo("failed to write plot file", dab.MagicFilename_Plot, err)
 	}
 	return nil
 }
@@ -57,13 +58,13 @@ func cmdQuickstart(c *cli.Context) error {
 		return fmt.Errorf("no module name provided")
 	}
 
-	_, err := os.Stat(util.ModuleFilename)
+	_, err := os.Stat(dab.MagicFilename_Module)
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("%s file already exists", util.ModuleFilename)
+		return fmt.Errorf("%s file already exists", dab.MagicFilename_Module)
 	}
-	_, err = os.Stat(util.PlotFilename)
+	_, err = os.Stat(dab.MagicFilename_Plot)
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("%s file already exists", util.PlotFilename)
+		return fmt.Errorf("%s file already exists", dab.MagicFilename_Plot)
 	}
 
 	moduleName := c.Args().First()
@@ -73,11 +74,11 @@ func cmdQuickstart(c *cli.Context) error {
 	}
 
 	if !c.Bool("quiet") {
-		fmt.Fprintf(c.App.Writer, "Successfully created %s and %s for module %q.\n", util.ModuleFilename, util.PlotFilename, moduleName)
+		fmt.Fprintf(c.App.Writer, "Successfully created %s and %s for module %q.\n", dab.MagicFilename_Module, dab.MagicFilename_Plot, moduleName)
 		fmt.Fprintf(c.App.Writer, "Ensure your catalogs are up to date by running `%s catalog update`.\n", os.Args[0])
 		fmt.Fprintf(c.App.Writer, "You can check status of this module with `%s status`.\n", os.Args[0])
 		fmt.Fprintf(c.App.Writer, "You can run this module with `%s run`.\n", os.Args[0])
-		fmt.Fprintf(c.App.Writer, "Once you've run the Hello World example, edit the 'script' section of %s to customize what happens.\n", util.PlotFilename)
+		fmt.Fprintf(c.App.Writer, "Once you've run the Hello World example, edit the 'script' section of %s to customize what happens.\n", dab.MagicFilename_Plot)
 	}
 
 	return nil

--- a/cmd/warpforge/status.go
+++ b/cmd/warpforge/status.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/warptools/warpforge/cmd/warpforge/internal/util"
+	"github.com/warptools/warpforge/pkg/dab"
 	"github.com/warptools/warpforge/pkg/formulaexec"
 	"github.com/warptools/warpforge/pkg/tracing"
 	"github.com/warptools/warpforge/wfapi"
@@ -94,12 +95,13 @@ func cmdStatus(c *cli.Context) error {
 		fmtWarning.Fprintf(c.App.Writer, "WARNING: plugins do not appear to be installed correctly.\n\n")
 	}
 
+	fsys := os.DirFS("/")
 	// check if pwd is a module, read module and set flag
 	isModule := false
 	var module wfapi.Module
-	if _, err := os.Stat(filepath.Join(pwd, util.ModuleFilename)); err == nil {
+	if _, err := os.Stat(filepath.Join(pwd, dab.MagicFilename_Module)); err == nil {
 		isModule = true
-		module, err = util.ModuleFromFile(filepath.Join(pwd, util.ModuleFilename))
+		module, err = dab.ModuleFromFile(fsys, filepath.Join(pwd, dab.MagicFilename_Module))
 		if err != nil {
 			return fmt.Errorf("failed to open module file: %s", err)
 		}
@@ -114,11 +116,11 @@ func cmdStatus(c *cli.Context) error {
 	// display module and plot info
 	var plot wfapi.Plot
 	hasPlot := false
-	_, err = os.Stat(filepath.Join(pwd, util.PlotFilename))
+	_, err = os.Stat(filepath.Join(pwd, dab.MagicFilename_Plot))
 	if isModule && err == nil {
 		// module.wf and plot.wf exists, read the plot
 		hasPlot = true
-		plot, err = util.PlotFromFile(filepath.Join(pwd, util.PlotFilename))
+		plot, err = util.PlotFromFile(filepath.Join(pwd, dab.MagicFilename_Plot))
 		if err != nil {
 			return fmt.Errorf("failed to open plot file: %s", err)
 		}

--- a/examples/200-module-parse/module-names.md
+++ b/examples/200-module-parse/module-names.md
@@ -1,0 +1,217 @@
+Module Names
+---
+
+Best practices for module names it to make them look similar to a DNS host names and URL path.
+
+```
+[[[...]]]subdomain.]subdomain.]domain[/path[/morepath[...]]]
+```
+
+We place restrictions on module names which ensures that they would be valid as such, but not all names which would be valid domains/URL paths are considered valid module names.
+As such our rules are heavily influenced by rules specified in [RFC-1123](https://datatracker.ietf.org/doc/html/rfc1123#section-2) and [RFC-1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1).
+
+Rules:
+  - Must contain only:
+    - ASCII lowercase alpha-numeric characters: `a-z0-9`.
+    - hyphens: `-`.
+    - dots: `.`.
+    - forward slash: `/`.
+  - Name MUST start AND end each path or domain segment with an ASCII lowercase alpha-numeric character.
+  - First path segment of the name MUST be 253 characters or less
+  - Each domain segment MUST only include ASCII, lowercase, alpha-numeric characters and hyphens '-'
+  - Each domain segment MUST be 63 characters or less
+
+
+# Valid Names
+
+These names are valid.
+
+[testmark]:# (valid/names)
+```
+my-domain.org
+my-domain.org/path/to/thing
+my.subdomain.domain.org/path-to-thing
+my-domain.org/path.to.thing
+```
+
+These are _also_ valid but are not recommended. Prefer to use a DNS host name that you own as the domain for your modules.
+
+[testmark]:# (valid/not-recommended)
+```
+my-domain
+my-domain/path/to/thing
+```
+
+
+# Invalid Names
+
+Names must not contain segments which are only dots. This would cause errors in filesystem projections.
+Additionally this breaks DNS naming rules where a name must begin with an alpha-numeric character.
+
+[testmark]:# (invalid/dots)
+```
+.
+..
+...
+./foo
+../foo
+.../foo
+my-domain.org/.
+my-domain.org/..
+my-domain.org/...
+my-domain.org/./foo
+my-domain.org/../foo
+my-domain.org/.../foo
+```
+
+Names are not allowed to contain uppercase characters.
+
+We do this even where it might be allowed because we don't implement case-folding.
+Projecting case-insensitive systems onto case-sensitive filesystems can be problematic.
+
+[testmark]:# (invalid/uppercase_domain)
+```
+mYdoMaIn
+my-domain.org/myPath
+```
+
+Segments must begin and end with an alpha-numeric character. That means no hyphens as the last character.
+
+[testmark]:# (invalid/hyphen/prefix)
+```
+  -my-domain.org
+  my-domain.org/-foo
+  my-domain.org/foo/-bar/grill
+```
+
+[testmark]:# (invalid/hyphen/suffix)
+```
+  my-domain.org-
+  my-domain.org/foo-
+  my-domain.org/foo/bar-/grill
+```
+
+Segments may not be empty. That means no trailing slashes.
+
+[testmark]:# (invalid/trailing-slash)
+```
+  /my-domain.org
+  my-domain.org/
+  my-domain.org/foo/
+  my-domain.org/foo/bar/
+```
+
+
+We don't allow underscores, but are strongly considering allowing them within **path** segments.
+If you feel that underscores would be nice-to-have or useful for you then let us know!
+
+[testmark]:# (invalid/underscores/in_path)
+```
+my-domain.org/a_path/to_a_thing
+```
+
+However we will NOT allow underscores as the _first_ character of any path. This would conflict with our
+filesystem projections which use `_thing` for internal files.
+
+[testmark]:# (invalid/underscores/prefix_always_invalid)
+```
+domain/_path
+domain/path/_to/thing
+```
+
+Using underscores as a suffix will likely be invalid as long as hyphens are invalid suffixes.
+
+[testmark]:# (invalid/underscores/suffix)
+```
+domain/path_
+domain/path/to_/thing
+```
+
+Underscores within domain segments will remain invalid.
+
+[testmark]:# (invalid/underscore/domain_always_invalid)
+```
+_domain
+_domain.org
+my_domain  
+my_domain.org
+```
+
+Whitespace is not allowed in module names.
+
+[testmark]:# (invalid/whitespace)
+```
+  my domain
+  my domain.org
+  mydomain.org/foo bar
+```
+
+Other punctuation is invalid in paths.
+
+[testmark]:# (invalid/punctuation/paths)
+```
+my-domain.org/foo:bar
+my-domain.org/foo!bar
+my-domain.org/foo~bar
+my-domain.org/foo;bar
+my-domain.org/foo'bar
+my-domain.org/foo"bar
+my-domain.org/foo`bar
+my-domain.org/foo#bar
+my-domain.org/foo$bar
+my-domain.org/foo%bar
+my-domain.org/foo&bar
+my-domain.org/foo(bar
+my-domain.org/foo)bar
+my-domain.org/foo*bar
+my-domain.org/foo+bar
+my-domain.org/foo,bar
+my-domain.org/foo\bar
+my-domain.org/foo—bar
+my-domain.org/foo<bar
+my-domain.org/foo>bar
+my-domain.org/foo=bar
+my-domain.org/foo?bar
+my-domain.org/foo@bar
+my-domain.org/foo[bar
+my-domain.org/foo]bar
+my-domain.org/foo^bar
+my-domain.org/foo{bar
+my-domain.org/foo}bar
+my-domain.org/foo|bar
+```
+
+Other punctuation is invalid in domains.
+
+[testmark]:# (invalid/punctuation/domains)
+```
+my:domain.org/foo/bar
+my!domain.org/foo/bar
+my~domain.org/foo/bar
+my;domain.org/foo/bar
+my'domain.org/foo/bar
+my"domain.org/foo/bar
+my`domain.org/foo/bar
+my#domain.org/foo/bar
+my$domain.org/foo/bar
+my%domain.org/foo/bar
+my&domain.org/foo/bar
+my(domain.org/foo/bar
+my)domain.org/foo/bar
+my*domain.org/foo/bar
+my+domain.org/foo/bar
+my,domain.org/foo/bar
+my\domain.org/foo/bar
+my—domain.org/foo/bar
+my<domain.org/foo/bar
+my>domain.org/foo/bar
+my=domain.org/foo/bar
+my?domain.org/foo/bar
+my@domain.org/foo/bar
+my[domain.org/foo/bar
+my]domain.org/foo/bar
+my^domain.org/foo/bar
+my{domain.org/foo/bar
+my}domain.org/foo/bar
+my|domain.org/foo/bar
+```

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -126,7 +126,7 @@ We'll run this in a filesystem that contains a `module.wf` (albeit a pretty sill
 ```
 {
 	"module.v1": {
-		"name": "test.org"
+		"name": "test"
 	}
 }
 ```
@@ -236,7 +236,7 @@ A module is declared with two files.  One is the `module.wf` file:
 ```
 {
 	"module.v1": {
-		"name": "test.org"
+		"name": "test"
 	}
 }
 ```
@@ -498,7 +498,7 @@ this file creates directories for a local workspace
 [testmark]:# (base-workspace/then-bundle/fs/workspace/module.wf)
 ```
 {
-	"name": "bundle.test",
+	"name": "bundle-test",
 }
 ```
 

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -126,7 +126,7 @@ We'll run this in a filesystem that contains a `module.wf` (albeit a pretty sill
 ```
 {
 	"module.v1": {
-		"name": "test"
+		"name": "test.org"
 	}
 }
 ```
@@ -151,9 +151,11 @@ We'll run this in a filesystem that contains a `plot.wf` (albeit a pretty silly 
 [testmark]:# (checkplot/fs/plot.wf)
 ```
 {
+	"plot.v1":{
     "inputs": {},
     "steps": {},
     "outputs": {}
+	}
 }
 ```
 
@@ -234,7 +236,7 @@ A module is declared with two files.  One is the `module.wf` file:
 ```
 {
 	"module.v1": {
-		"name": "test"
+		"name": "test.org"
 	}
 }
 ```
@@ -305,7 +307,7 @@ Here's the `plot.wf` file -- this one's a bit bigger and more involved:
 									}
 								}
 							}
-						},
+						}
 					},
 					"outputs": {
 						"test": "pipe:one-inner:test"
@@ -496,7 +498,7 @@ this file creates directories for a local workspace
 [testmark]:# (base-workspace/then-bundle/fs/workspace/module.wf)
 ```
 {
-	"name": "bundle-test",
+	"name": "bundle.test",
 }
 ```
 

--- a/pkg/dab/filetype.go
+++ b/pkg/dab/filetype.go
@@ -1,0 +1,51 @@
+package dab
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/serum-errors/go-serum"
+
+	"github.com/warptools/warpforge/wfapi"
+)
+
+type FileType string
+
+const MagicFilename_Formula = "formula.wf"
+const (
+	FileType_Module  FileType = "module"
+	FileType_Plot    FileType = "plot"
+	FileType_Formula FileType = "formula"
+)
+
+var magicFileTypes = map[string]FileType{
+	MagicFilename_Module:  FileType_Module,
+	MagicFilename_Plot:    FileType_Plot,
+	MagicFilename_Formula: FileType_Formula,
+}
+var types = map[FileType]struct{}{
+	FileType_Module:  {},
+	FileType_Plot:    {},
+	FileType_Formula: {},
+}
+
+// GetFileType returns the file type, which is the file name without extension
+// e.g., formula.wf -> formula, module.wf -> module, etc...
+//
+// Errors:
+//
+//   - warpforge-error-invalid -- if the file name is not recognized
+func GetFileType(name string) (FileType, error) {
+	base := filepath.Base(name)
+	if ft, ok := magicFileTypes[base]; ok {
+		return ft, nil
+	}
+	ft := FileType(strings.TrimSuffix(base, filepath.Ext(base)))
+	if _, ok := types[ft]; ok {
+		return ft, nil
+	}
+	return "", serum.Error(wfapi.ECodeInvalid,
+		serum.WithMessageTemplate("file {{name | q }} is an unknown file type"),
+		serum.WithDetail("name", name),
+	)
+}

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -59,7 +59,6 @@ var (
 //         - dots '.'
 //         - forward slash '/'.
 //    - Name MUST start AND end each path or domain segment with an ASCII lowercase alpha-numeric character.
-//    - First path segment of the name MUST include a dot '.' character
 //    - First path segment of the name MUST be 253 characters or less
 //    - Each domain segment MUST only include ASCII, lowercase, alpha-numeric characters and hyphens '-'
 //    - Each domain segment MUST be 63 characters or less

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -39,6 +39,12 @@ var (
 )
 
 // ValidateModuleName checks the module name for invalid strings.
+//
+// Examples of valid module names:
+//    - foobar
+//    - foo.bar/grill
+//    - foo-bar
+//
 // "Path segments" are defined as the segments separated by forward slash "/".
 // "Domain segments" are defined as the segments separated by dot "." and only applies to the first path segment.
 //
@@ -49,7 +55,6 @@ var (
 // The rules are summarized as following:
 //    - Name MUST contain only:
 //         - ASCII lowercase alpha-numeric characters
-//         - underscores '_'
 //         - hyphens '-'
 //         - dots '.'
 //         - forward slash '/'.

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -3,9 +3,13 @@ package dab
 import (
 	"fmt"
 	"io/fs"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/serum-errors/go-serum"
 
 	"github.com/warptools/warpforge/wfapi"
 )
@@ -14,6 +18,49 @@ const (
 	MagicFilename_Module = "module.wf"
 	MagicFilename_Plot   = "plot.wf"
 )
+
+var (
+	alphaNumReFmt               = `[a-zA-Z0-9]`
+	wordReFmt                   = `[-a-zA-Z0-9_\.]`
+	segmentReFmt                = fmt.Sprintf(`(%s%s*)?%s`, alphaNumReFmt, wordReFmt, alphaNumReFmt)
+	firstSegmentReFmt           = fmt.Sprintf(`%[1]s\.%[1]s`, segmentReFmt)
+	reModuleFirstSegment        = regexp.MustCompile(`^` + firstSegmentReFmt + `$`)
+	reModuleName                = regexp.MustCompile(`^` + firstSegmentReFmt + `(/` + segmentReFmt + `)*$`)
+	moduleFirstSegmentMaxLength = 63 // limit first segment to encourage compatibility with DNS domain name rules
+)
+
+// ValidateModuleName checks the module name for invalid strings.
+// Name "path segments" are defined as the segments separated by forward slash "/".
+//
+// Module names have the following rules:
+//    - Name MUST start AND end each segment with an ASCII alpha-numeric character.
+//    - Name MUST contain only ASCII alpha-numeric characters plus underscores '_', hyphens '-', dots '.', and forward slash '/'.
+//    - First segment of the name MUST include a dot '.' character and must be 63 characters or less
+//
+// Errors:
+//
+//  - warpforge-error-module-invalid -- when module name is invalid
+func ValidateModuleName(moduleName wfapi.ModuleName) error {
+	name := string(moduleName)
+	parts := strings.Split(name, "/")
+	if !reModuleFirstSegment.MatchString(parts[0]) {
+		// test first segment separately so we can add a more specific error message
+		return serum.Error(wfapi.ECodeModuleInvalid,
+			serum.WithMessageLiteral("first segment of module name must both start and end with an alphanumeric character, must contain at least one '.', and must consist of alphanumeric characters, '-', '_', or '.'"),
+			serum.WithDetail("name", strconv.Quote(name)),
+		)
+	}
+	if !reModuleName.MatchString(name) {
+		return serum.Error(wfapi.ECodeModuleInvalid,
+			serum.WithMessageLiteral("module name segments must both start and end with an alphanumeric character and must consist of alphanumeric characters, '-', '_', or '.'"),
+			serum.WithDetail("name", strconv.Quote(name)),
+		)
+	}
+	if len(parts[0]) > moduleFirstSegmentMaxLength {
+		return serum.Errorf(wfapi.ECodeModuleInvalid, "first segment of module name may not be longer than %d characters", moduleFirstSegmentMaxLength)
+	}
+	return nil
+}
 
 // ModuleFromFile loads a wfapi.Module from filesystem path.
 //
@@ -24,10 +71,12 @@ const (
 // 	- warpforge-error-io -- for errors reading from fsys.
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Module.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
-//
+//  - warpforge-error-module-invalid -- when module name is invalid
 func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
-	situation := "loading a module"
-
+	const situation = "loading a module"
+	if strings.HasPrefix(filename, "/") {
+		filename = filename[1:]
+	}
 	f, err := fs.ReadFile(fsys, filename)
 	if err != nil {
 		return wfapi.Module{}, wfapi.ErrorIo(situation, filename, err)
@@ -43,6 +92,10 @@ func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
 		return wfapi.Module{}, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Module in ModuleCapsule"))
 	}
 
+	if err := ValidateModuleName(moduleCapsule.Module.Name); err != nil {
+		return wfapi.Module{}, err
+	}
+
 	return *moduleCapsule.Module, nil
 }
 
@@ -55,10 +108,12 @@ func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
 // 	- warpforge-error-io -- for errors reading from fsys.
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Plot.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
-//
 func PlotFromFile(fsys fs.FS, filename string) (wfapi.Plot, error) {
-	situation := "loading a plot"
+	const situation = "loading a plot"
 
+	if strings.HasPrefix(filename, "/") {
+		filename = filename[1:]
+	}
 	f, err := fs.ReadFile(fsys, filename)
 	if err != nil {
 		return wfapi.Plot{}, wfapi.ErrorIo(situation, filename, err)

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -19,23 +19,45 @@ const (
 	MagicFilename_Plot   = "plot.wf"
 )
 
+// See validateDNS1123Subdomain and ValidateModuleName
+const (
+	// similar to dns1123 label hunks, but allows mid-string dots also.
+	validation_moduleNamePathHunk_regexpStr string = "[a-z0-9]([-a-z0-9\\.]*[a-z0-9])?"
+	validation_moduleNamePathHunk_msg       string = "must consist of lower case alphanumeric characters or '-' or '.', and must start and end with an alphanumeric character"
+	validation_moduleNamePathHunk_maxlen    int    = 63
+	validation_dns1123Label_regexpStr       string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+	validation_dns1123Label_msg             string = "must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+	validation_dns1123Label_maxlen          int    = 63
+	validation_dns1123Subdomain_regexpStr   string = validation_dns1123Label_regexpStr + "(\\." + validation_dns1123Label_regexpStr + ")*"
+	validation_dns1123Subdomain_msg         string = "must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+	validation_dns1123Subdomain_maxlen      int    = 253
+)
+
 var (
-	alphaNumReFmt               = `[a-zA-Z0-9]`
-	wordReFmt                   = `[-a-zA-Z0-9_\.]`
-	segmentReFmt                = fmt.Sprintf(`(%s%s*)?%s`, alphaNumReFmt, wordReFmt, alphaNumReFmt)
-	firstSegmentReFmt           = fmt.Sprintf(`%[1]s\.%[1]s`, segmentReFmt)
-	reModuleFirstSegment        = regexp.MustCompile(`^` + firstSegmentReFmt + `$`)
-	reModuleName                = regexp.MustCompile(`^` + firstSegmentReFmt + `(/` + segmentReFmt + `)*$`)
-	moduleFirstSegmentMaxLength = 63 // limit first segment to encourage compatibility with DNS domain name rules
+	validation_moduleNamePathHunk_regexp = regexp.MustCompile("^" + validation_moduleNamePathHunk_regexpStr + "$")
+	validation_dns1123Subdomain_regexp   = regexp.MustCompile("^" + validation_dns1123Subdomain_regexpStr + "$")
 )
 
 // ValidateModuleName checks the module name for invalid strings.
-// Name "path segments" are defined as the segments separated by forward slash "/".
+// "Path segments" are defined as the segments separated by forward slash "/".
+// "Domain segments" are defined as the segments separated by dot "." and only applies to the first path segment.
 //
-// Module names have the following rules:
-//    - Name MUST start AND end each segment with an ASCII alpha-numeric character.
-//    - Name MUST contain only ASCII alpha-numeric characters plus underscores '_', hyphens '-', dots '.', and forward slash '/'.
-//    - First segment of the name MUST include a dot '.' character and must be 63 characters or less
+// A module name must resemble a domain name (per DNS RFC 1123 & 1035) with optional subsequent path segments. I.E.
+//
+//    [[[...]]]subdomain.]subdomain.]domain[/path[/morepath[...]]]
+//
+// The rules are summarized as following:
+//    - Name MUST contain only:
+//         - ASCII lowercase alpha-numeric characters
+//         - underscores '_'
+//         - hyphens '-'
+//         - dots '.'
+//         - forward slash '/'.
+//    - Name MUST start AND end each path or domain segment with an ASCII lowercase alpha-numeric character.
+//    - First path segment of the name MUST include a dot '.' character
+//    - First path segment of the name MUST be 253 characters or less
+//    - Each domain segment MUST only include ASCII, lowercase, alpha-numeric characters and hyphens '-'
+//    - Each domain segment MUST be 63 characters or less
 //
 // Errors:
 //
@@ -43,21 +65,114 @@ var (
 func ValidateModuleName(moduleName wfapi.ModuleName) error {
 	name := string(moduleName)
 	parts := strings.Split(name, "/")
-	if !reModuleFirstSegment.MatchString(parts[0]) {
+	if err := validateDNS1123Subdomain(parts[0]); err != nil {
 		// test first segment separately so we can add a more specific error message
 		return serum.Error(wfapi.ECodeModuleInvalid,
-			serum.WithMessageLiteral("first segment of module name must both start and end with an alphanumeric character, must contain at least one '.', and must consist of alphanumeric characters, '-', '_', or '.'"),
-			serum.WithDetail("name", strconv.Quote(name)),
+			serum.WithDetail("name", escape(name)),
+			serum.WithCause(err),
 		)
 	}
-	if !reModuleName.MatchString(name) {
-		return serum.Error(wfapi.ECodeModuleInvalid,
-			serum.WithMessageLiteral("module name segments must both start and end with an alphanumeric character and must consist of alphanumeric characters, '-', '_', or '.'"),
-			serum.WithDetail("name", strconv.Quote(name)),
+	for _, pathHunk := range parts[1:] {
+		if err := validateModuleNamePathHunk(pathHunk); err != nil {
+			return serum.Error(wfapi.ECodeModuleInvalid,
+				serum.WithDetail("name", escape(name)),
+				serum.WithCause(err),
+			)
+		}
+	}
+	return nil
+}
+
+func validateModuleNamePathHunk(value string) error {
+	if len(value) > validation_moduleNamePathHunk_maxlen {
+		return serum.Error(wfapi.ECodeInvalid,
+			serum.WithMessageTemplate("value must be no more than {{limit}} characters"),
+			serum.WithDetail("limit", strconv.Itoa(validation_moduleNamePathHunk_maxlen)),
 		)
 	}
-	if len(parts[0]) > moduleFirstSegmentMaxLength {
-		return serum.Errorf(wfapi.ECodeModuleInvalid, "first segment of module name may not be longer than %d characters", moduleFirstSegmentMaxLength)
+	if !validation_moduleNamePathHunk_regexp.MatchString(value) {
+		return serum.Error(wfapi.ECodeInvalid,
+			serum.WithMessageLiteral(validation_moduleNamePathHunk_msg),
+		)
+	}
+	return nil
+}
+
+// escape limits strings to ascii characters. This will help when debugging
+// unicode characters which are invisible, whitespace, or look-alikes to other characters.
+// escape will convert any such characters into escape sequences.
+func escape(name string) string {
+	qName := strconv.QuoteToASCII(name)
+	qName = qName[1 : len(qName)-1] // remove double quotes
+	return qName
+}
+
+// validateDNS1123Subdomain implements restrictions for DNS names
+//
+// Based on of RFC 1123 (section 2.5)
+//    - MUST allow host name to begin with a digit
+//    - MUST allow host names of up to 63 characters
+//    - SHOULD allow host names of up to 255 characters
+// NOTE: We've shortened subdomain maximum length to 253 characters because
+// that's what we did before and what kubernetes does.
+//
+// Based on RFC 1035 (secion 2.3)
+// <<<
+//     <domain> ::= <subdomain> | " "
+//
+//     <subdomain> ::= <label> | <subdomain> "." <label>
+//
+//     <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
+//
+//     <ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+//
+//     <let-dig-hyp> ::= <let-dig> | "-"
+//
+//     <let-dig> ::= <letter> | <digit>
+//
+//     <letter> ::= any one of the 52 alphabetic characters A through Z in
+//     upper case and a through z in lower case
+//
+//     <digit> ::= any one of the ten digits 0 through 9
+//
+//     Note that while upper and lower case letters are allowed in domain
+//     names, no significance is attached to the case.  That is, two names with
+//     the same spelling but different case are to be treated as if identical.
+//
+//     The labels must follow the rules for ARPANET host names.  They must
+//     start with a letter, end with a letter or digit, and have as interior
+//     characters only letters, digits, and hyphen.  There are also some
+//     restrictions on the length.  Labels must be 63 characters or less.
+// >>>
+// We do not implement case folding and therefore domains MUST be lowercase.
+//
+// Errors:
+//
+//   - warpforge-error-invalid -- when the string fails validation
+func validateDNS1123Subdomain(value string) error {
+	if len(value) > validation_dns1123Subdomain_maxlen {
+		return serum.Error(wfapi.ECodeInvalid,
+			serum.WithMessageTemplate("domain must be no more than {{limit}} characters"),
+			serum.WithDetail("limit", strconv.Itoa(validation_dns1123Subdomain_maxlen)),
+		)
+	}
+	if !validation_dns1123Subdomain_regexp.MatchString(value) {
+		return serum.Error(wfapi.ECodeInvalid,
+			serum.WithMessageLiteral(validation_dns1123Subdomain_msg),
+		)
+	}
+	lastDotIdx := 0
+	for i, r := range value {
+		if r == '.' {
+			lastDotIdx = i + 1
+		}
+		if i-lastDotIdx >= validation_dns1123Label_maxlen {
+			return serum.Error(wfapi.ECodeInvalid,
+				serum.WithMessageTemplate("subdomain must be no more than {{limit}} characters"),
+				serum.WithDetail("limit", strconv.Itoa(validation_dns1123Label_maxlen)),
+				serum.WithDetail("label", value[lastDotIdx+1:i]),
+			)
+		}
 	}
 	return nil
 }

--- a/pkg/dab/module_test.go
+++ b/pkg/dab/module_test.go
@@ -1,0 +1,147 @@
+package dab_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/warptools/warpforge/pkg/dab"
+	"github.com/warptools/warpforge/wfapi"
+)
+
+func TestValidateModuleName(t *testing.T) {
+	for _, testcase := range []struct {
+		name    string
+		checker qt.Checker
+	}{
+		// good names | happy path
+		{"example.com", qt.IsNil},
+		{"example.com/b", qt.IsNil},
+		{"a.b/c", qt.IsNil},
+		{"a.b.c", qt.IsNil},
+		{"abc.def.ghi/jkl", qt.IsNil},
+		{"abc_def.ghi/jkl", qt.IsNil},
+		{"abc-def.ghi/jkl", qt.IsNil},
+		{"example.com/b/c", qt.IsNil},
+		{"1.2", qt.IsNil},
+		{"1.2/3", qt.IsNil},
+		{"1.2/3/4", qt.IsNil},
+		{"a.b/foo", qt.IsNil},
+		{"a.b/foobar", qt.IsNil},
+		{"a.b/foo_bar", qt.IsNil},
+		{"a.b/foo/bar", qt.IsNil},
+		// cannot start or end segment with non-alphanumeric characters
+		{".a.b/foo/bar", qt.IsNotNil},
+		{"_a.b/foo/bar", qt.IsNotNil},
+		{"-a.b/foo/bar", qt.IsNotNil},
+		{"a.b./foo/bar", qt.IsNotNil},
+		{"a.b_/foo/bar", qt.IsNotNil},
+		{"a.b-/foo/bar", qt.IsNotNil},
+		{"a.b/.foo/bar", qt.IsNotNil},
+		{"a.b/_foo/bar", qt.IsNotNil},
+		{"a.b/-foo/bar", qt.IsNotNil},
+		{"a.b/foo./bar", qt.IsNotNil},
+		{"a.b/foo_/bar", qt.IsNotNil},
+		{"a.b/foo-/bar", qt.IsNotNil},
+		{"a.b/foo/.bar", qt.IsNotNil},
+		{"a.b/foo/_bar", qt.IsNotNil},
+		{"a.b/foo/-bar", qt.IsNotNil},
+		{"a.b/foo/bar.", qt.IsNotNil},
+		{"a.b/foo/bar_", qt.IsNotNil},
+		{"a.b/foo/bar-", qt.IsNotNil},
+		// punctuation
+		{"a.b/foo:bar", qt.IsNotNil},
+		{"a.b/foo!bar", qt.IsNotNil},
+		{"a.b/foo~bar", qt.IsNotNil},
+		{"a.b/foo;bar", qt.IsNotNil},
+		{"a.b/foo'bar", qt.IsNotNil},
+		{`a.b/foo"bar`, qt.IsNotNil},
+		{"a.b/foo`bar", qt.IsNotNil},
+		{"a.b/foo#bar", qt.IsNotNil},
+		{"a.b/foo$bar", qt.IsNotNil},
+		{"a.b/foo%bar", qt.IsNotNil},
+		{"a.b/foo&bar", qt.IsNotNil},
+		{"a.b/foo(bar", qt.IsNotNil},
+		{"a.b/foo)bar", qt.IsNotNil},
+		{"a.b/foo*bar", qt.IsNotNil},
+		{"a.b/foo+bar", qt.IsNotNil},
+		{"a.b/foo,bar", qt.IsNotNil},
+		{`a.b/foo\bar`, qt.IsNotNil},
+		{"a.b/foo—bar", qt.IsNotNil},
+		{"a.b/foo<bar", qt.IsNotNil},
+		{"a.b/foo>bar", qt.IsNotNil},
+		{"a.b/foo=bar", qt.IsNotNil},
+		{"a.b/foo?bar", qt.IsNotNil},
+		{"a.b/foo@bar", qt.IsNotNil},
+		{"a.b/foo[bar", qt.IsNotNil},
+		{"a.b/foo]bar", qt.IsNotNil},
+		{"a.b/foo^bar", qt.IsNotNil},
+		{"a.b/foo{bar", qt.IsNotNil},
+		{"a.b/foo}bar", qt.IsNotNil},
+		{"a.b/foo|bar", qt.IsNotNil},
+		// segments containing only dots
+		{".", qt.IsNotNil},
+		{"..", qt.IsNotNil},
+		{"...", qt.IsNotNil},
+		{"./a", qt.IsNotNil},
+		{"../a", qt.IsNotNil},
+		{".../a", qt.IsNotNil},
+		{"a.b/.", qt.IsNotNil},
+		{"a.b/..", qt.IsNotNil},
+		{"a.b/...", qt.IsNotNil},
+		{"a.b/./b", qt.IsNotNil},
+		{"a.b/../b", qt.IsNotNil},
+		{"a.b/.../b", qt.IsNotNil},
+		// segments beginning with underscores
+		{"_a.b", qt.IsNotNil},
+		{"a.b/_foo", qt.IsNotNil},
+		{"_a.b/foo/bar", qt.IsNotNil},
+		{"a.b/_foo/bar", qt.IsNotNil},
+		{"a.b/foo/_bar", qt.IsNotNil},
+		// empty segments
+		{"", qt.IsNotNil},
+		{"a.b/", qt.IsNotNil},
+		{"/foo", qt.IsNotNil},
+		{"a.b//foo", qt.IsNotNil},
+		{"a.b/foo//bar", qt.IsNotNil},
+		// whitespace
+		{" ", qt.IsNotNil},
+		{"a.b/foo ", qt.IsNotNil}, // ends with space
+		{"a.b/foo\t", qt.IsNotNil},
+		{"a.b/foo\n", qt.IsNotNil},
+		{"a.b/foo\r", qt.IsNotNil},
+		{"a.b/foo\v", qt.IsNotNil},
+		{"a.b/foo\f", qt.IsNotNil},
+		{"a.b/foo\u00A0", qt.IsNotNil}, //NBSP
+		{"a.b/foo\u0085", qt.IsNotNil}, //NEL
+		{"a.b/foo bar", qt.IsNotNil},
+		{"a.b/foo\tbar", qt.IsNotNil},
+		{"a.b/foo\nbar", qt.IsNotNil},
+		{"a.b/foo\rbar", qt.IsNotNil},
+		{"a.b/foo\vbar", qt.IsNotNil},
+		{"a.b/foo\fbar", qt.IsNotNil},
+		{"a.b/foo\u00A0bar", qt.IsNotNil}, //NBSP
+		{"a.b/foo\u0085bar", qt.IsNotNil}, //NEL
+		{"a.b/foo/bar ", qt.IsNotNil},     // ends with space
+		// control codes
+		{"\b", qt.IsNotNil},
+		{"a.b/\b", qt.IsNotNil},
+		{"a.b/foo\b", qt.IsNotNil},
+		{"a.b/foo/bar\b", qt.IsNotNil},
+		{"a.b/foo\bbar", qt.IsNotNil},
+		// length
+		{strings.Repeat("a", 62) + ".b", qt.IsNotNil},                              // DNS rules are 63 characters for domain names, we're loosely going to encourage compatibility by setting a length limit
+		{strings.Repeat("a", 61) + ".b" + "/" + strings.Repeat("c", 64), qt.IsNil}, // only first segment is length limited
+	} {
+		testcase := testcase
+		name := fmt.Sprintf("%#v", testcase.name)
+		t.Run(name, func(t *testing.T) {
+			t.Logf("%#v", testcase.name)
+			moduleName := wfapi.ModuleName(testcase.name)
+			result := dab.ValidateModuleName(moduleName)
+			qt.Assert(t, result, testcase.checker)
+		})
+	}
+}

--- a/pkg/dab/module_test.go
+++ b/pkg/dab/module_test.go
@@ -11,135 +11,163 @@ import (
 	"github.com/warptools/warpforge/wfapi"
 )
 
+var veryLongDomain = strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 61)
+var manySubdomains = strings.Repeat("a.", 126) + "b"
+
 func TestValidateModuleName(t *testing.T) {
+	qt.Assert(t, veryLongDomain, qt.HasLen, 253)
+	qt.Assert(t, manySubdomains, qt.HasLen, 253)
 	for _, testcase := range []struct {
-		name    string
+		name    string // if left empty will use the value name
+		value   string
 		checker qt.Checker
 	}{
 		// good names | happy path
-		{"example.com", qt.IsNil},
-		{"example.com/b", qt.IsNil},
-		{"a.b/c", qt.IsNil},
-		{"a.b.c", qt.IsNil},
-		{"abc.def.ghi/jkl", qt.IsNil},
-		{"abc_def.ghi/jkl", qt.IsNil},
-		{"abc-def.ghi/jkl", qt.IsNil},
-		{"example.com/b/c", qt.IsNil},
-		{"1.2", qt.IsNil},
-		{"1.2/3", qt.IsNil},
-		{"1.2/3/4", qt.IsNil},
-		{"a.b/foo", qt.IsNil},
-		{"a.b/foobar", qt.IsNil},
-		{"a.b/foo_bar", qt.IsNil},
-		{"a.b/foo/bar", qt.IsNil},
+		{"", "example", qt.IsNil},
+		{"", "example.com", qt.IsNil},
+		{"", "example.com/b", qt.IsNil},
+		{"", "a.b/c", qt.IsNil},
+		{"", "a.b.c", qt.IsNil},
+		{"", "abc.def.ghi/jkl", qt.IsNil},
+		{"", "abc-def.ghi/jkl", qt.IsNil},
+		{"", "example.com/b/c", qt.IsNil},
+		{"", "1.2", qt.IsNil},
+		{"", "1.2/3", qt.IsNil},
+		{"", "1.2/3/4", qt.IsNil},
+		{"", "a.b/foo", qt.IsNil},
+		{"", "a.b/foobar", qt.IsNil},
+		{"", "a.b/foo/bar", qt.IsNil},
+		// underscore considered for valid chars but removed
+		{"", "abc_def.ghi/jkl", qt.IsNotNil},
+		{"", "a.b/foo_bar", qt.IsNotNil},
 		// cannot start or end segment with non-alphanumeric characters
-		{".a.b/foo/bar", qt.IsNotNil},
-		{"_a.b/foo/bar", qt.IsNotNil},
-		{"-a.b/foo/bar", qt.IsNotNil},
-		{"a.b./foo/bar", qt.IsNotNil},
-		{"a.b_/foo/bar", qt.IsNotNil},
-		{"a.b-/foo/bar", qt.IsNotNil},
-		{"a.b/.foo/bar", qt.IsNotNil},
-		{"a.b/_foo/bar", qt.IsNotNil},
-		{"a.b/-foo/bar", qt.IsNotNil},
-		{"a.b/foo./bar", qt.IsNotNil},
-		{"a.b/foo_/bar", qt.IsNotNil},
-		{"a.b/foo-/bar", qt.IsNotNil},
-		{"a.b/foo/.bar", qt.IsNotNil},
-		{"a.b/foo/_bar", qt.IsNotNil},
-		{"a.b/foo/-bar", qt.IsNotNil},
-		{"a.b/foo/bar.", qt.IsNotNil},
-		{"a.b/foo/bar_", qt.IsNotNil},
-		{"a.b/foo/bar-", qt.IsNotNil},
+		{"", ".a.b/foo/bar", qt.IsNotNil},
+		{"", "_a.b/foo/bar", qt.IsNotNil},
+		{"", "-a.b/foo/bar", qt.IsNotNil},
+		{"", "a.b./foo/bar", qt.IsNotNil},
+		{"", "a.b_/foo/bar", qt.IsNotNil},
+		{"", "a.b-/foo/bar", qt.IsNotNil},
+		{"", "a.b/.foo/bar", qt.IsNotNil},
+		{"", "a.b/_foo/bar", qt.IsNotNil},
+		{"", "a.b/-foo/bar", qt.IsNotNil},
+		{"", "a.b/foo./bar", qt.IsNotNil},
+		{"", "a.b/foo_/bar", qt.IsNotNil},
+		{"", "a.b/foo-/bar", qt.IsNotNil},
+		{"", "a.b/foo/.bar", qt.IsNotNil},
+		{"", "a.b/foo/_bar", qt.IsNotNil},
+		{"", "a.b/foo/-bar", qt.IsNotNil},
+		{"", "a.b/foo/bar.", qt.IsNotNil},
+		{"", "a.b/foo/bar_", qt.IsNotNil},
+		{"", "a.b/foo/bar-", qt.IsNotNil},
 		// punctuation
-		{"a.b/foo:bar", qt.IsNotNil},
-		{"a.b/foo!bar", qt.IsNotNil},
-		{"a.b/foo~bar", qt.IsNotNil},
-		{"a.b/foo;bar", qt.IsNotNil},
-		{"a.b/foo'bar", qt.IsNotNil},
-		{`a.b/foo"bar`, qt.IsNotNil},
-		{"a.b/foo`bar", qt.IsNotNil},
-		{"a.b/foo#bar", qt.IsNotNil},
-		{"a.b/foo$bar", qt.IsNotNil},
-		{"a.b/foo%bar", qt.IsNotNil},
-		{"a.b/foo&bar", qt.IsNotNil},
-		{"a.b/foo(bar", qt.IsNotNil},
-		{"a.b/foo)bar", qt.IsNotNil},
-		{"a.b/foo*bar", qt.IsNotNil},
-		{"a.b/foo+bar", qt.IsNotNil},
-		{"a.b/foo,bar", qt.IsNotNil},
-		{`a.b/foo\bar`, qt.IsNotNil},
-		{"a.b/foo—bar", qt.IsNotNil},
-		{"a.b/foo<bar", qt.IsNotNil},
-		{"a.b/foo>bar", qt.IsNotNil},
-		{"a.b/foo=bar", qt.IsNotNil},
-		{"a.b/foo?bar", qt.IsNotNil},
-		{"a.b/foo@bar", qt.IsNotNil},
-		{"a.b/foo[bar", qt.IsNotNil},
-		{"a.b/foo]bar", qt.IsNotNil},
-		{"a.b/foo^bar", qt.IsNotNil},
-		{"a.b/foo{bar", qt.IsNotNil},
-		{"a.b/foo}bar", qt.IsNotNil},
-		{"a.b/foo|bar", qt.IsNotNil},
+		{"", "a.b/foo:bar", qt.IsNotNil},
+		{"", "a.b/foo!bar", qt.IsNotNil},
+		{"", "a.b/foo~bar", qt.IsNotNil},
+		{"", "a.b/foo;bar", qt.IsNotNil},
+		{"", "a.b/foo'bar", qt.IsNotNil},
+		{"", `a.b/foo"bar`, qt.IsNotNil},
+		{"", "a.b/foo`bar", qt.IsNotNil},
+		{"", "a.b/foo#bar", qt.IsNotNil},
+		{"", "a.b/foo$bar", qt.IsNotNil},
+		{"", "a.b/foo%bar", qt.IsNotNil},
+		{"", "a.b/foo&bar", qt.IsNotNil},
+		{"", "a.b/foo(bar", qt.IsNotNil},
+		{"", "a.b/foo)bar", qt.IsNotNil},
+		{"", "a.b/foo*bar", qt.IsNotNil},
+		{"", "a.b/foo+bar", qt.IsNotNil},
+		{"", "a.b/foo,bar", qt.IsNotNil},
+		{"", `a.b/foo\bar`, qt.IsNotNil},
+		{"", "a.b/foo—bar", qt.IsNotNil},
+		{"", "a.b/foo<bar", qt.IsNotNil},
+		{"", "a.b/foo>bar", qt.IsNotNil},
+		{"", "a.b/foo=bar", qt.IsNotNil},
+		{"", "a.b/foo?bar", qt.IsNotNil},
+		{"", "a.b/foo@bar", qt.IsNotNil},
+		{"", "a.b/foo[bar", qt.IsNotNil},
+		{"", "a.b/foo]bar", qt.IsNotNil},
+		{"", "a.b/foo^bar", qt.IsNotNil},
+		{"", "a.b/foo{bar", qt.IsNotNil},
+		{"", "a.b/foo}bar", qt.IsNotNil},
+		{"", "a.b/foo|bar", qt.IsNotNil},
 		// segments containing only dots
-		{".", qt.IsNotNil},
-		{"..", qt.IsNotNil},
-		{"...", qt.IsNotNil},
-		{"./a", qt.IsNotNil},
-		{"../a", qt.IsNotNil},
-		{".../a", qt.IsNotNil},
-		{"a.b/.", qt.IsNotNil},
-		{"a.b/..", qt.IsNotNil},
-		{"a.b/...", qt.IsNotNil},
-		{"a.b/./b", qt.IsNotNil},
-		{"a.b/../b", qt.IsNotNil},
-		{"a.b/.../b", qt.IsNotNil},
+		{"", ".", qt.IsNotNil},
+		{"", "..", qt.IsNotNil},
+		{"", "...", qt.IsNotNil},
+		{"", "./a", qt.IsNotNil},
+		{"", "../a", qt.IsNotNil},
+		{"", ".../a", qt.IsNotNil},
+		{"", "a.b/.", qt.IsNotNil},
+		{"", "a.b/..", qt.IsNotNil},
+		{"", "a.b/...", qt.IsNotNil},
+		{"", "a.b/./b", qt.IsNotNil},
+		{"", "a.b/../b", qt.IsNotNil},
+		{"", "a.b/.../b", qt.IsNotNil},
 		// segments beginning with underscores
-		{"_a.b", qt.IsNotNil},
-		{"a.b/_foo", qt.IsNotNil},
-		{"_a.b/foo/bar", qt.IsNotNil},
-		{"a.b/_foo/bar", qt.IsNotNil},
-		{"a.b/foo/_bar", qt.IsNotNil},
+		{"", "_a.b", qt.IsNotNil},
+		{"", "a.b/_foo", qt.IsNotNil},
+		{"", "_a.b/foo/bar", qt.IsNotNil},
+		{"", "a.b/_foo/bar", qt.IsNotNil},
+		{"", "a.b/foo/_bar", qt.IsNotNil},
 		// empty segments
-		{"", qt.IsNotNil},
-		{"a.b/", qt.IsNotNil},
-		{"/foo", qt.IsNotNil},
-		{"a.b//foo", qt.IsNotNil},
-		{"a.b/foo//bar", qt.IsNotNil},
+		{"", "", qt.IsNotNil},
+		{"", "a.b/", qt.IsNotNil},
+		{"", "/foo", qt.IsNotNil},
+		{"", "a.b//foo", qt.IsNotNil},
+		{"", "a.b/foo//bar", qt.IsNotNil},
 		// whitespace
-		{" ", qt.IsNotNil},
-		{"a.b/foo ", qt.IsNotNil}, // ends with space
-		{"a.b/foo\t", qt.IsNotNil},
-		{"a.b/foo\n", qt.IsNotNil},
-		{"a.b/foo\r", qt.IsNotNil},
-		{"a.b/foo\v", qt.IsNotNil},
-		{"a.b/foo\f", qt.IsNotNil},
-		{"a.b/foo\u00A0", qt.IsNotNil}, //NBSP
-		{"a.b/foo\u0085", qt.IsNotNil}, //NEL
-		{"a.b/foo bar", qt.IsNotNil},
-		{"a.b/foo\tbar", qt.IsNotNil},
-		{"a.b/foo\nbar", qt.IsNotNil},
-		{"a.b/foo\rbar", qt.IsNotNil},
-		{"a.b/foo\vbar", qt.IsNotNil},
-		{"a.b/foo\fbar", qt.IsNotNil},
-		{"a.b/foo\u00A0bar", qt.IsNotNil}, //NBSP
-		{"a.b/foo\u0085bar", qt.IsNotNil}, //NEL
-		{"a.b/foo/bar ", qt.IsNotNil},     // ends with space
+		{"", " ", qt.IsNotNil},
+		{"", "a.b/foo ", qt.IsNotNil}, // ends with space
+		{"", "a.b/foo\t", qt.IsNotNil},
+		{"", "a.b/foo\n", qt.IsNotNil},
+		{"", "a.b/foo\r", qt.IsNotNil},
+		{"", "a.b/foo\v", qt.IsNotNil},
+		{"", "a.b/foo\f", qt.IsNotNil},
+		{"", "a.b/foo\u00A0", qt.IsNotNil}, //NBSP
+		{"", "a.b/foo\u0085", qt.IsNotNil}, //NEL
+		{"", "a.b/foo bar", qt.IsNotNil},
+		{"", "a.b/foo\tbar", qt.IsNotNil},
+		{"", "a.b/foo\nbar", qt.IsNotNil},
+		{"", "a.b/foo\rbar", qt.IsNotNil},
+		{"", "a.b/foo\vbar", qt.IsNotNil},
+		{"", "a.b/foo\fbar", qt.IsNotNil},
+		{"", "a.b/foo\u00A0bar", qt.IsNotNil}, //NBSP
+		{"", "a.b/foo\u0085bar", qt.IsNotNil}, //NEL
+		{"", "a.b/foo/bar ", qt.IsNotNil},     // ends with space
 		// control codes
-		{"\b", qt.IsNotNil},
-		{"a.b/\b", qt.IsNotNil},
-		{"a.b/foo\b", qt.IsNotNil},
-		{"a.b/foo/bar\b", qt.IsNotNil},
-		{"a.b/foo\bbar", qt.IsNotNil},
+		{"", "\b", qt.IsNotNil},
+		{"", "a.b/\b", qt.IsNotNil},
+		{"", "a.b/foo\b", qt.IsNotNil},
+		{"", "a.b/foo/bar\b", qt.IsNotNil},
+		{"", "a.b/foo\bbar", qt.IsNotNil},
+		// uppercase
+		{"", "A", qt.IsNotNil},
+		{"", "A.b", qt.IsNotNil},
+		{"", "a.B", qt.IsNotNil},
+		{"", "A.b.c", qt.IsNotNil},
+		{"", "a.B.c", qt.IsNotNil},
+		{"", "a.b.C", qt.IsNotNil},
+		{"", "a.b.c/D", qt.IsNotNil},
+		{"", "a.b.c/D/e", qt.IsNotNil},
+		{"", "a.b.c/d/E", qt.IsNotNil},
 		// length
-		{strings.Repeat("a", 62) + ".b", qt.IsNotNil},                              // DNS rules are 63 characters for domain names, we're loosely going to encourage compatibility by setting a length limit
-		{strings.Repeat("a", 61) + ".b" + "/" + strings.Repeat("c", 64), qt.IsNil}, // only first segment is length limited
+		{"64 chars", strings.Repeat("a", 64), qt.IsNotNil}, // DNS label limit
+		{"63 chars", strings.Repeat("a", 63), qt.IsNil},
+		{"63*2 chars", strings.Repeat("a", 63) + "." + strings.Repeat("b", 63), qt.IsNil},
+		{fmt.Sprintf("%d chars", len(veryLongDomain)), veryLongDomain, qt.IsNil},
+		{fmt.Sprintf("%d chars", len(veryLongDomain)+1), veryLongDomain + "x", qt.IsNotNil},
+		{"many subdomains", manySubdomains, qt.IsNil},
+		{"one too many subdomains", manySubdomains + ".x", qt.IsNotNil},
+		{"pathlen 63", "example.org/" + strings.Repeat("a", 63), qt.IsNil},
+		{"pathlen 64", "example.org/" + strings.Repeat("a", 64), qt.IsNotNil},
 	} {
 		testcase := testcase
-		name := fmt.Sprintf("%#v", testcase.name)
+		name := testcase.name
+		if name == "" {
+			name = fmt.Sprintf("%#v", testcase.value)
+		}
 		t.Run(name, func(t *testing.T) {
-			t.Logf("%#v", testcase.name)
-			moduleName := wfapi.ModuleName(testcase.name)
+			t.Logf("%#v", testcase.value)
+			moduleName := wfapi.ModuleName(testcase.value)
 			result := dab.ValidateModuleName(moduleName)
 			qt.Assert(t, result, testcase.checker)
 		})

--- a/pkg/plumbing/doc.go
+++ b/pkg/plumbing/doc.go
@@ -1,4 +1,7 @@
 // The plumbing package is where the actual business logic for warpforge commands resides.
 // This differs from the cmd/warpforge directory which is specifically a CLI application.
 // The purpose is to create a clear split between CLI application  concerns and business logic of warpforge.
+//
+// No packages outside of cmd/ is expected to import plumbing packages. This set of packages is glue to glue
+// where we stitch together the other pieces of warpforge.
 package plumbing

--- a/pkg/plumbing/doc.go
+++ b/pkg/plumbing/doc.go
@@ -2,6 +2,6 @@
 // This differs from the cmd/warpforge directory which is specifically a CLI application.
 // The purpose is to create a clear split between CLI application  concerns and business logic of warpforge.
 //
-// No packages outside of cmd/ is expected to import plumbing packages. This set of packages is glue to glue
-// where we stitch together the other pieces of warpforge.
+// No packages outside of cmd/ is expected to import plumbing packages. This set of packages is where
+// we stitch together the other pieces of warpforge.
 package plumbing

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -343,6 +343,7 @@ func (c *Config) Run(ctx context.Context) error {
 //    - warpforge-error-serialization -- when the module or plot cannot be parsed
 //    - warpforge-error-unknown -- when changing directories fails
 //    - warpforge-error-workspace -- when opening the workspace set fails
+//    - warpforge-error-module-invalid -- when module name is invalid
 func execModule(ctx context.Context, config wfapi.PlotExecConfig, modulePath string) (wfapi.PlotResults, error) {
 	ctx, span := tracing.Start(ctx, "execModule")
 	defer span.End()

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -10,6 +10,8 @@ import (
 
 // TODO: Add comments for reasons to use or not use particular codes
 const (
+	// ECodeArgument may be used when invalid arguments are provided to the warpforge command line
+	ECodeArgument = "warpforge-error-invalid-argument"
 	// ECodeAlreadyExists may be used when _something_ already exists.
 	// Prefer to use a more specific error code or specify _what_ is missing.
 	ECodeAlreadyExists          = "warpforge-error-already-exists"


### PR DESCRIPTION
Also refactors some utility functions by placing them into the dab package. Overall this helps ensure that modules are being validated by centralizing the module file handling.