### PR TITLE
Use .warphome as the name for the home workspace

### DIFF
--- a/pkg/dab/workspace.go
+++ b/pkg/dab/workspace.go
@@ -2,4 +2,5 @@ package dab
 
 const (
 	MagicFilename_Workspace = ".warpforge"
+	MagicFilename_HomeWorkspace = ".warphome"
 )

--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -685,16 +685,13 @@ func execFormula(ctx context.Context, ws *workspace.Workspace, fc wfapi.FormulaA
 	}
 
 	// get the root workspace location
-	var wsPath string
-	if ws != nil {
-		_, wsPath = ws.Path()
-	} else {
+	if ws == nil {
 		return rr, wfapi.ErrorWorkspace("", fmt.Errorf("no root workspace path was provided for formula exec"))
 	}
-	wsPath = filepath.Join("/", wsPath, ".warpforge")
+	wsPath := filepath.Join("/", ws.InternalPath())
 
 	// ensure a warehouse dir exists within the root workspace
-	warehousePath := filepath.Join(wsPath, "warehouse")
+	warehousePath := filepath.Join("/", ws.WarehousePath())
 	errRaw = os.MkdirAll(warehousePath, 0755)
 	if errRaw != nil {
 		return rr, wfapi.ErrorIo("failed to create warehouse", warehousePath, errRaw)

--- a/pkg/plotexec/plot_exec.go
+++ b/pkg/plotexec/plot_exec.go
@@ -191,11 +191,9 @@ func plotInputToFormulaInputSimple(ctx context.Context,
 		// TODO: unclear if this should happen here or elsewhere
 		if wareAddr == nil {
 			// check if the ware is already in the warehouse
-			_, wsPath := wsSet.Root().Path()
+			root := wsSet.Root()
 			warehousePath := filepath.Join("/",
-				wsPath,
-				".warpforge",
-				"warehouse",
+				root.WarehousePath(),
 				wareId.Hash[0:3], wareId.Hash[3:6], wareId.Hash)
 			if _, err := os.Stat(filepath.Join("/", warehousePath)); os.IsNotExist(err) {
 				// ware not found, run the replay to generate it

--- a/pkg/workspace/fsdetect_test.go
+++ b/pkg/workspace/fsdetect_test.go
@@ -24,7 +24,7 @@ func TestWorkspaceDetection(t *testing.T) {
 	homedir = "home/user"
 	t.Run("happy-path", func(t *testing.T) {
 		fsys := fstest.MapFS{
-			"home/user/.warpforge":                     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/.warphome":                      &fstest.MapFile{Mode: 0755 | fs.ModeDir},
 			"home/user/foobar-proj/.warpforge":         &fstest.MapFile{Mode: 0755 | fs.ModeDir},
 			"home/user/workspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
 			"home/user/workspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},


### PR DESCRIPTION
This stops is from being possible to acceidently get some one else's home workspace as part of your workspace stack.