### PR TITLE
Make relative mounts relative to formula/module

### DIFF
--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -493,7 +493,7 @@ func cmdCatalogRelease(c *cli.Context) error {
 		return err
 	}
 
-	execCfg, err := config.PlotExecConfig()
+	execCfg, err := config.PlotExecConfig(nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -58,11 +58,13 @@ func cmdFerk(c *cli.Context) error {
 	ctx := c.Context
 	log := logging.Ctx(ctx)
 	plot := wfapi.Plot{}
+	var plotFile string
 	if c.String("plot") != "" {
+		plotFile := c.String("plot")
 		// plot was provided, load from file
-		plot, err = util.PlotFromFile(c.String("plot"))
+		plot, err = util.PlotFromFile(plotFile)
 		if err != nil {
-			return serum.Error(wfapi.ECodePlotInvalid, serum.WithMessageTemplate("plot file {{file}} not parsed"), serum.WithCause(err), serum.WithDetail("file", c.String("plot")))
+			return serum.Error(wfapi.ECodePlotInvalid, serum.WithMessageTemplate("plot file {{file}} not parsed"), serum.WithCause(err), serum.WithDetail("file", plotFile))
 		}
 	} else {
 		// no plot provided, generate the basic default plot from json template
@@ -70,6 +72,9 @@ func cmdFerk(c *cli.Context) error {
 		if err != nil {
 			return wfapi.ErrorSerialization("error parsing template plot", err)
 		}
+
+		// set a fake plotFile value
+		plotFile = "plot.wf"
 
 		// convert rootfs input string to PlotInput
 		// this requires additional quoting to be parsed correctly by ipld
@@ -129,7 +134,8 @@ func cmdFerk(c *cli.Context) error {
 		},
 	}
 
-	exCfg, err := config.PlotExecConfig()
+	plotDir := filepath.Dir(plotFile)
+	exCfg, err := config.PlotExecConfig(&plotDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/warpforge/internal/healthcheck/execute.go
+++ b/cmd/warpforge/internal/healthcheck/execute.go
@@ -115,7 +115,7 @@ func (e *ExecutionInfo) Run(ctx context.Context) error {
 		},
 	}
 
-	exCfg, err := config.PlotExecConfig()
+	exCfg, err := config.PlotExecConfig(&e.BasePath)
 	if err != nil {
 		return serum.Error(CodeRunFailure, serum.WithCause(err))
 	}

--- a/cmd/warpforge/internal/util/util.go
+++ b/cmd/warpforge/internal/util/util.go
@@ -134,7 +134,8 @@ func ExecModule(ctx context.Context, wss workspace.WorkspaceSet, pltCfg wfapi.Pl
 		return result, err
 	}
 
-	execCfg, err := config.PlotExecConfig()
+	moduleDir := filepath.Dir(fileName)
+	execCfg, err := config.PlotExecConfig(&moduleDir)
 	if err != nil {
 		return result, err
 	}

--- a/cmd/warpforge/run.go
+++ b/cmd/warpforge/run.go
@@ -127,7 +127,8 @@ func cmdRun(c *cli.Context) error {
 				if err != nil {
 					return err
 				}
-				frmExecCfg, err := config.FormulaExecConfig()
+				formulaDir := filepath.Dir(fileName)
+				frmExecCfg, err := config.FormulaExecConfig(&formulaDir)
 				if err != nil {
 					return err
 				}

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -364,6 +364,63 @@ there's only one record in this map.
 { "plotresults": { "test": "tar:4tvpCNb1XJ3gkH25MREMPBHRWa7gLUiYt7pF6AHNbqgwBrs3btvvmijebyZrYsi6Y9" } } 
 ```
 
+## Relative Paths
+
+Plots can have relative paths for mounts. These paths are relative to the
+plot file itself. This example executes a module from a different directory
+to demonstrate how relative paths work.
+
+[testmark]:# (base-workspace/then-test-mounts/sequence)
+```
+warpforge --json --quiet run module
+```
+
+[testmark]:# (base-workspace/then-test-mounts/fs/module/module.wf)
+```
+{
+	"module.v1": {
+		"name": "test"
+	}
+}
+```
+
+[testmark]:# (base-workspace/then-test-mounts/fs/module/test.txt)
+```
+hello from a mounted file!
+```
+
+[testmark]:# (base-workspace/then-test-mounts/fs/module/plot.wf)
+```
+{
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:warpsys.org/busybox:v1.35.0:amd64-static"
+		},
+		"steps": {
+			"one": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs"
+						"/mnt": "mount:overlay:."
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/sh",
+								"-c",
+								"cat /mnt/test.txt"
+							]
+						}
+					},
+					"outputs": {}
+				}
+			}
+		},
+		"outputs": {}
+	}
+}
+```
+
 ## Catalog Operations
 
 [testmark]:# (catalog/tags=net/fs/.warpforge/root)

--- a/pkg/config/exec_config.go
+++ b/pkg/config/exec_config.go
@@ -61,15 +61,15 @@ func WarehousePathOverride() *string {
 // Errors:
 //
 //    - warpforge-error-initialization -- unable to get working or executable directories
-func PlotExecConfig() (plotexec.ExecConfig, error) {
-	cfg, err := FormulaExecConfig()
+func PlotExecConfig(modulePath *string) (plotexec.ExecConfig, error) {
+	cfg, err := FormulaExecConfig(modulePath)
 	return plotexec.ExecConfig(cfg), err
 }
 
 // Errors:
 //
 //    - warpforge-error-initialization -- unable to get working or executable directories
-func FormulaExecConfig() (cfg formulaexec.ExecConfig, _ error) {
+func FormulaExecConfig(formulaPath *string) (cfg formulaexec.ExecConfig, _ error) {
 	binpath, err := BinPath()
 	if err != nil {
 		return cfg, nil
@@ -81,11 +81,30 @@ func FormulaExecConfig() (cfg formulaexec.ExecConfig, _ error) {
 			serum.WithCause(err),
 		)
 	}
+
+	// if a nil formulaDirectory is provided, default to WorkingDirectory
+	// otherwise, set as a relative path to WorkingDirectory if relative
+	// or just use the absolute path if absolute
+	var formulaDirectory string
+	if formulaPath == nil {
+		// none provided, use WorkingDirectory
+		formulaDirectory = wd
+	} else {
+		if filepath.IsAbs(*formulaPath) {
+			// absolute path provided use as is
+			formulaDirectory = *formulaPath
+		} else {
+			// relative path provided, construct path relative to
+			// working directory
+			formulaDirectory = filepath.Join(wd, *formulaPath)
+		}
+	}
 	return formulaexec.ExecConfig{
 		BinPath:          binpath,
 		KeepRunDir:       KeepRunDir(),
 		RunPathBase:      RunPathBase(),
 		WhPathOverride:   WarehousePathOverride(),
 		WorkingDirectory: wd,
+		FormulaDirectory: formulaDirectory,
 	}, nil
 }

--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -86,8 +86,11 @@ type ExecConfig struct {
 	RunPathBase string
 	// WarehousePathOverride overrides the directory where outputs are stored.
 	WhPathOverride *string
-	// WorkingDirectory will be where relative paths are based from.
+	// WorkingDirectory is the directory we are running warpforge from
 	WorkingDirectory string
+	// FormulaDirectory is the location of the formula (or module) being run
+	// Relative mount paths are relative to this path
+	FormulaDirectory string
 }
 
 func (cfg *ExecConfig) debug(ctx context.Context) {
@@ -845,7 +848,7 @@ func execFormula(ctx context.Context, cfg internalConfig) (wfapi.RunRecord, erro
 					hostPath = inputSimple.Mount.HostPath
 				} else {
 					// otherwise, use relative path
-					hostPath = filepath.Join(cfg.WorkingDirectory, inputSimple.Mount.HostPath)
+					hostPath = filepath.Join(cfg.FormulaDirectory, inputSimple.Mount.HostPath)
 				}
 			}
 

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -384,7 +384,7 @@ func exec(ctx context.Context, pltCfg wfapi.PlotExecConfig, modulePathAbs string
 	if err != nil {
 		return result, err
 	}
-	exCfg, err := config.PlotExecConfig()
+	exCfg, err := config.PlotExecConfig(&modulePathAbs)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
With the shuffling of paths, we ended up making mounts relative to the working directory where `warpforge` is executed. This is probably not what we want, since we have Formulas that provide relative paths to the `formula.wf` (or `module.wf` / `plot.wf`) file.

This resolves that by adding a parameter to `FormulaExecConfig` / `PlotExecConfig`. If provided, this specifies the path to use for relative mounts (`FormulaDirectory`).

This also adds a test which uses the CLI testing. This seemed like the best way to build and test a filesystem.