### PR TITLE
Ferk tweaks

### DIFF
--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -178,7 +178,6 @@ func cmdFerk_selectPlot(c *cli.Context) (*wfapi.Plot, *string, error) {
 		}
 		return &plot, nil, nil
 	}
-	fmt.Println("plot is", c.String("plot"))
 
 	// Look for module and plot files.
 	// If we received a filename: expect that to be a plot.

--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -181,5 +181,14 @@ func cmdFerk_selectPlot(c *cli.Context) (plot *wfapi.Plot, plotDir string, err e
 	}
 	m, p, f, _, _, err := dab.FindActionableFromFS(os.DirFS("/"), pth, "", false, dab.ActionableSearch_Any)
 	_, _ = m, f // TODO support these
+	if err != nil {
+		return nil, "", err
+	}
+	if p == nil {
+		return nil, "", serum.Error(wfapi.ECodeMissing,
+			serum.WithMessageTemplate("could not find a plot given path {{path|q}}"),
+			serum.WithDetail("path", pth),
+		)
+	}
 	return p, pth, err
 }

--- a/cmd/warpforge/internal/util/util.go
+++ b/cmd/warpforge/internal/util/util.go
@@ -86,6 +86,7 @@ func canonicalizePath(pwd, path string) string {
 //    - warpforge-error-catalog-invalid --
 //    - warpforge-error-catalog-parse --
 //    - warpforge-error-git --
+//    - warpforge-error-missing -- when a required file is missing
 //    - warpforge-error-io -- when the module or plot files cannot be read or cannot change directory.
 //    - warpforge-error-catalog-missing-entry --
 //    - warpforge-error-module-invalid -- when the module data is invalid

--- a/cmd/warpforge/internal/util/util.go
+++ b/cmd/warpforge/internal/util/util.go
@@ -128,7 +128,7 @@ func ExecModule(ctx context.Context, wss workspace.WorkspaceSet, pltCfg wfapi.Pl
 		return result, werr
 	}
 
-	result, werr = plotexec.Exec(ctx, execCfg, wss, wfapi.PlotCapsule{Plot: &plot}, pltCfg)
+	result, werr = plotexec.Exec(ctx, execCfg, wss, wfapi.PlotCapsule{Plot: plot}, pltCfg)
 
 	if werr != nil {
 		return result, wfapi.ErrorPlotExecutionFailed(werr)

--- a/cmd/warpforge/status.go
+++ b/cmd/warpforge/status.go
@@ -98,17 +98,15 @@ func cmdStatus(c *cli.Context) error {
 	fsys := os.DirFS("/")
 
 	// check if pwd is a module, read module and set flag
-	isModule := false
-	var module wfapi.Module
+	var module *wfapi.Module
 	if _, err := os.Stat(filepath.Join(cwd, dab.MagicFilename_Module)); err == nil {
-		isModule = true
 		module, err = dab.ModuleFromFile(fsys, filepath.Join(cwd, dab.MagicFilename_Module))
 		if err != nil {
 			return fmt.Errorf("failed to open module file: %s", err)
 		}
 	}
 
-	if isModule {
+	if module != nil {
 		fmt.Fprintf(c.App.Writer, "Module %q:\n", module.Name)
 	} else {
 		fmt.Fprintf(c.App.Writer, "No module in this directory.\n")
@@ -118,7 +116,7 @@ func cmdStatus(c *cli.Context) error {
 	var plot wfapi.Plot
 	hasPlot := false
 	_, err = os.Stat(filepath.Join(cwd, dab.MagicFilename_Plot))
-	if isModule && err == nil {
+	if module != nil && err == nil {
 		// module.wf and plot.wf exists, read the plot
 		hasPlot = true
 		plot, err = util.PlotFromFile(filepath.Join(cwd, dab.MagicFilename_Plot))
@@ -175,7 +173,7 @@ func cmdStatus(c *cli.Context) error {
 		if mountCount > 0 {
 			fmt.Fprintf(c.App.Writer, "\tWarning: plot contains %d mount inputs and is not hermetic!\n", mountCount)
 		}
-	} else if isModule {
+	} else if module != nil {
 		// directory is a module, but has no plot
 		fmt.Fprintf(c.App.Writer, "\tNo plot file for module.\n")
 	}
@@ -189,7 +187,7 @@ func cmdStatus(c *cli.Context) error {
 
 	// handle special case for pwd
 	fmt.Fprintf(c.App.Writer, "\t%s (pwd", cwd)
-	if isModule {
+	if module != nil {
 		fmt.Fprintf(c.App.Writer, ", module")
 	}
 	// check if it's a workspace
@@ -249,7 +247,7 @@ func cmdStatus(c *cli.Context) error {
 		fmt.Fprintf(c.App.Writer, ")\n")
 	}
 
-	if isModule && hasPlot {
+	if module != nil && hasPlot {
 		fmtBold.Fprintf(c.App.Writer, "\nYou can evaluate this module with the `%s run` command.\n", os.Args[0])
 	}
 

--- a/pkg/dab/find.go
+++ b/pkg/dab/find.go
@@ -82,7 +82,15 @@ func open(fsys fs.FS, path string) (fs.File, error) {
 // The foundPath and remainingSearchPath values are always returned,
 // even in the case of errors.
 //
-// Errors: none
+// Errors:
+//
+//  - warpforge-error-datatoonew -- when found data is not supported by this version of warpforge
+//  - warpforge-error-invalid-argument -- when a file contains the wrong content for its filename
+//  - warpforge-error-io -- when an IO error occurs during search
+//  - warpforge-error-missing -- when an expected file is missing
+//  - warpforge-error-module-invalid -- when a read module contains invalid data
+//  - warpforge-error-searching-filesystem -- when the search of the filesystem produces an invalid result
+//  - warpforge-error-serialization -- when IPLD deserialization fails
 func FindActionableFromFS(
 	fsys fs.FS,
 	basisPath string, searchPath string, searchUp bool,

--- a/pkg/dab/find.go
+++ b/pkg/dab/find.go
@@ -1,0 +1,205 @@
+package dab
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/serum-errors/go-serum"
+	"github.com/warptools/warpforge/wfapi"
+)
+
+// ActionableSearch is a bitfield for what the ActionableFromFS function should treat as acceptable findings.
+type ActionableSearch uint8
+
+const (
+	ActionableSearch_None    ActionableSearch = 0
+	ActionableSearch_Formula ActionableSearch = 1      // Use this bitflag to indicate a formula is an acceptable search result.
+	ActionableSearch_Module  ActionableSearch = 1 << 1 // Use this bitflag to indicate a module is an acceptable search result.  Modules almost always have a plot associated with them, which will also be loaded by most search functions.
+	ActionableSearch_Plot    ActionableSearch = 1 << 2 // A module can always also have a plot; use this if a bare plot (no module) is acceptable.
+
+	ActionableSearch_Any ActionableSearch = ActionableSearch_Formula | ActionableSearch_Module | ActionableSearch_Plot
+)
+
+// FindActionableFromFS loads either module (and plot) from the fileystem,
+// or instead a Formula,
+// while also accepting directories as input and applying reasonable heuristics.
+//
+// FindActionableFromFS is suitable for finding *one* module/plot/formula;
+// finding groupings of modules (i.e., handling args of "./..." forms) is a different feature.
+//
+// The 'fsys' parameter is typically `os.DirFS("/")` except in test environments.
+//
+// The 'basisPath' and 'searchPath' parameters work together to specify which paths to inspect.
+// The `{basisPath}/{searchPath}` path will always be searched;
+// and if the 'searchUp' parameter is true, then each segment of 'searchPath'
+// will also be popped and searched.
+// (If 'searchUp' is false, the distinction between 'basisPath' and 'searchPath' vanishes.)
+//
+// If `{basisPath}/{searchPath}` contains a file, only file is inspected,
+// and search up through parent directories is not performed regardless of the value of 'searchUp'.
+//
+// The typical values of 'basisPath' and 'searchPath' vary depending on feature, but are usually one of:
+// basisPath is the CWD, and searchPath was a CLI argument;
+// or, basisPath is empty string (meaning the root of the filesystem), and searchPath is the CWD (possibly joined with a CLI argument);
+// or, basisPath is a workspace directory, and searchPath is the CWD within that (possibly joined with a CLI argument).
+// Neither value should ever have a leading slash (as is typical for APIs using FS).
+//
+// The 'accept' parameter can be used to have the function ignore (or return errors) in some scenarios.
+// For example, 'ActionableSearch_Any' may cause the search to return a formula or a module;
+// whereas if you only want only want to detect modules, you should use 'ActionableSearch_Module' instead.
+// See the comments on the constants for details on other options.
+//
+// It is possible for a module and plot to be returned;
+// or a module alone; or a plot alone; or a formula alone;
+// or an error; or all four of them may be nil at once if the search found nothing.
+// The foundPath and remainingSearchPath values are always returned,
+// even in the case of errors.
+func FindActionableFromFS(
+	fsys fs.FS,
+	basisPath string, searchPath string, searchUp bool,
+	accept ActionableSearch,
+) (
+	m *wfapi.Module, p *wfapi.Plot, f *wfapi.Formula,
+	foundPath string, remainingSearchPath string, err error,
+) {
+	remainingSearchPath = searchPath
+
+	// First round: this may be a file, and may be one of any of the types.
+	// Stat it and consider that first:
+	// if it is a file, that's its own whole detection procedure (and means no further search);
+	// if it's not a file, we can procede to the behavior for dir feature detection (without popping).
+	foundPath = filepath.Join(basisPath, remainingSearchPath)
+	fi, e2 := fs.Stat(fsys, foundPath)
+	if e2 != nil {
+		err = e2
+		return
+	}
+	if fi.Mode()&^fs.ModePerm == 0 {
+		fh, e2 := fsys.Open(foundPath)
+		defer fh.Close()
+		if e2 != nil {
+			err = e2
+			return
+		}
+		m, p, f, err = findActionableFromFile(fh, accept)
+		if m != nil { // If a module was found, a plot may also exist as a sibling file.
+			p, e2 = PlotFromFile(fsys, filepath.Join(filepath.Dir(filepath.Join(basisPath, remainingSearchPath)), "plot.wf"))
+			if !errors.Is(e2, fs.ErrNotExist) {
+				err = wfapi.ErrorSearchingFilesystem("loading plot associated with a module", e2)
+			}
+		}
+		return
+	}
+
+	// Iteratively check directories.
+	// In each directory, look for well-known file names.
+	// If we find a module, that dominates; then plot; then formula.
+	// When there's no match, if searchUp is enabled, then pop one segment off searchPath and search again.
+	for {
+		// Peek for module.
+		if accept&ActionableSearch_Module > 0 {
+			foundPath = filepath.Join(basisPath, remainingSearchPath, "module.wf")
+			m, e2 = ModuleFromFile(fsys, foundPath)
+			if !errors.Is(e2, fs.ErrNotExist) { // notexist is ignored.
+				// Any error that's just just notexist: means our search has blind spots: error out.
+				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
+				return
+			}
+			// A module may also have a plot next to it; load that eagerly too.
+			p, e2 = PlotFromFile(fsys, filepath.Join(basisPath, remainingSearchPath, "plot.wf"))
+			if !errors.Is(e2, fs.ErrNotExist) {
+				err = wfapi.ErrorSearchingFilesystem("loading plot associated with a module", e2)
+			}
+			return
+		}
+		// Peek for plot.
+		if accept&ActionableSearch_Plot > 0 {
+			foundPath = filepath.Join(basisPath, remainingSearchPath, "plot.wf")
+			p, e2 = PlotFromFile(fsys, foundPath)
+			if !errors.Is(e2, fs.ErrNotExist) { // notexist is ignored.
+				// Any error that's just just notexist: means our search has blind spots: error out.
+				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
+				return
+			}
+		}
+
+		// Peek for Formula.
+		// TODO
+
+		// None of the filename peeks found a thing?
+		// Okay.  If we can search further up, let's do so.
+		if !searchUp {
+			foundPath = ""
+			return
+		}
+		remainingSearchPath = filepath.Dir(remainingSearchPath)
+		if remainingSearchPath == "/" || remainingSearchPath == "." {
+			return
+		}
+	}
+}
+
+// findActionableFromFile peeks at the first few bytes of a stream
+// to guess whether it's a module, a plot, or a formula, and returns the right one.
+func findActionableFromFile(r io.Reader, accept ActionableSearch) (
+	m *wfapi.Module, p *wfapi.Plot, f *wfapi.Formula, err error,
+) {
+	peekSize := 1024
+	br := bufio.NewReaderSize(r, peekSize)
+	peek, _ := br.Peek(peekSize)
+	marker, err := GuessDocumentType(peek, []string{
+		"module.v1",
+		"plot.v1",
+		"formula",
+	})
+	if err != nil {
+		return
+	}
+	switch marker {
+	case "module.v1":
+		if accept&ActionableSearch_Module == 0 {
+			err = serum.Error(wfapi.ECodeArgument,
+				serum.WithMessageLiteral("file contained a module document when a module is not expected"),
+			)
+			return
+		}
+		capsule := wfapi.ModuleCapsule{}
+		_, e2 := ipld.UnmarshalStreaming(br, json.Decode, &capsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
+		if e2 != nil {
+			err = wfapi.ErrorSerialization("parsing what appeared to be a module", err)
+		} else {
+			m = capsule.Module
+		}
+		return
+	case "plot.v1":
+		if accept&ActionableSearch_Plot == 0 {
+			err = serum.Error(wfapi.ECodeArgument,
+				serum.WithMessageLiteral("file contained a plot document when a plot is not expected"),
+			)
+			return
+		}
+		capsule := wfapi.PlotCapsule{}
+		_, e2 := ipld.UnmarshalStreaming(br, json.Decode, &capsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
+		if e2 != nil {
+			err = wfapi.ErrorSerialization("parsing what appeared to be a plot", err)
+		} else {
+			p = capsule.Plot
+		}
+		return
+	case "formula":
+		if accept&ActionableSearch_Formula == 0 {
+			err = serum.Error(wfapi.ECodeArgument,
+				serum.WithMessageLiteral("file contained a formula document when a formula is not expected"),
+			)
+			return
+		}
+		panic("not yet supported") // TODO FormulaAndContext is a little funky and might need reexamination.  Returning multiple values for that case is unpleasant.
+	default:
+		panic("unreachable")
+	}
+}

--- a/pkg/dab/find.go
+++ b/pkg/dab/find.go
@@ -17,9 +17,9 @@ type ActionableSearch uint8
 
 const (
 	ActionableSearch_None    ActionableSearch = 0
-	ActionableSearch_Formula ActionableSearch = 1 << (iota - 1) // Use this bitflag to indicate a formula is an acceptable search result.
-	ActionableSearch_Module                                     // Use this bitflag to indicate a module is an acceptable search result.  Modules almost always have a plot associated with them, which will also be loaded by most search functions.
-	ActionableSearch_Plot                                       // A module can always also have a plot; use this if a bare plot (no module) is acceptable.
+	ActionableSearch_Formula ActionableSearch = 1 << iota // Use this bitflag to indicate a formula is an acceptable search result.
+	ActionableSearch_Module                               // Use this bitflag to indicate a module is an acceptable search result.  Modules almost always have a plot associated with them, which will also be loaded by most search functions.
+	ActionableSearch_Plot                                 // A module can always also have a plot; use this if a bare plot (no module) is acceptable.
 
 	ActionableSearch_Any ActionableSearch = ActionableSearch_Formula | ActionableSearch_Module | ActionableSearch_Plot
 )

--- a/pkg/dab/find.go
+++ b/pkg/dab/find.go
@@ -129,14 +129,14 @@ func FindActionableFromFS(
 		if accept&ActionableSearch_Module > 0 {
 			foundPath = filepath.Join(basisPath, remainingSearchPath, "module.wf")
 			m, e2 = ModuleFromFile(fsys, foundPath)
-			if !errors.Is(e2, fs.ErrNotExist) { // notexist is ignored.
+			if serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
 				// Any error that's just just notexist: means our search has blind spots: error out.
 				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
 				return
 			}
 			// A module may also have a plot next to it; load that eagerly too.
 			p, e2 = PlotFromFile(fsys, filepath.Join(basisPath, remainingSearchPath, "plot.wf"))
-			if !errors.Is(e2, fs.ErrNotExist) {
+			if serum.Code(e2) != wfapi.ECodeMissing {
 				err = wfapi.ErrorSearchingFilesystem("loading plot associated with a module", e2)
 			}
 			return
@@ -145,7 +145,7 @@ func FindActionableFromFS(
 		if accept&ActionableSearch_Plot > 0 {
 			foundPath = filepath.Join(basisPath, remainingSearchPath, "plot.wf")
 			p, e2 = PlotFromFile(fsys, foundPath)
-			if !errors.Is(e2, fs.ErrNotExist) { // notexist is ignored.
+			if serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
 				// Any error that's just just notexist: means our search has blind spots: error out.
 				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
 				return

--- a/pkg/dab/find.go
+++ b/pkg/dab/find.go
@@ -18,9 +18,9 @@ type ActionableSearch uint8
 
 const (
 	ActionableSearch_None    ActionableSearch = 0
-	ActionableSearch_Formula ActionableSearch = 1      // Use this bitflag to indicate a formula is an acceptable search result.
-	ActionableSearch_Module  ActionableSearch = 1 << 1 // Use this bitflag to indicate a module is an acceptable search result.  Modules almost always have a plot associated with them, which will also be loaded by most search functions.
-	ActionableSearch_Plot    ActionableSearch = 1 << 2 // A module can always also have a plot; use this if a bare plot (no module) is acceptable.
+	ActionableSearch_Formula ActionableSearch = 1 << (iota - 1) // Use this bitflag to indicate a formula is an acceptable search result.
+	ActionableSearch_Module                                     // Use this bitflag to indicate a module is an acceptable search result.  Modules almost always have a plot associated with them, which will also be loaded by most search functions.
+	ActionableSearch_Plot                                       // A module can always also have a plot; use this if a bare plot (no module) is acceptable.
 
 	ActionableSearch_Any ActionableSearch = ActionableSearch_Formula | ActionableSearch_Module | ActionableSearch_Plot
 )
@@ -104,7 +104,7 @@ func FindActionableFromFS(
 	// First round: this may be a file, and may be one of any of the types.
 	// Stat it and consider that first:
 	// if it is a file, that's its own whole detection procedure (and means no further search);
-	// if it's not a file, we can procede to the behavior for dir feature detection (without popping).
+	// if it's not a file, we can proceed to the behavior for dir feature detection (without popping).
 	foundPath = filepath.Join(basisPath, remainingSearchPath)
 	fi, e2 := stat(fsys, foundPath)
 	if e2 != nil {
@@ -137,14 +137,14 @@ func FindActionableFromFS(
 		if accept&ActionableSearch_Module > 0 {
 			foundPath = filepath.Join(basisPath, remainingSearchPath, "module.wf")
 			m, e2 = ModuleFromFile(fsys, foundPath)
-			if serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
+			if e2 != nil && serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
 				// Any error that's just just notexist: means our search has blind spots: error out.
 				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
 				return
 			}
 			// A module may also have a plot next to it; load that eagerly too.
 			p, e2 = PlotFromFile(fsys, filepath.Join(basisPath, remainingSearchPath, "plot.wf"))
-			if serum.Code(e2) != wfapi.ECodeMissing {
+			if e2 != nil && serum.Code(e2) != wfapi.ECodeMissing {
 				err = wfapi.ErrorSearchingFilesystem("loading plot associated with a module", e2)
 			}
 			return
@@ -153,7 +153,7 @@ func FindActionableFromFS(
 		if accept&ActionableSearch_Plot > 0 {
 			foundPath = filepath.Join(basisPath, remainingSearchPath, "plot.wf")
 			p, e2 = PlotFromFile(fsys, foundPath)
-			if serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
+			if e2 != nil && serum.Code(e2) != wfapi.ECodeMissing { // notexist is ignored.
 				// Any error that's just just notexist: means our search has blind spots: error out.
 				err = wfapi.ErrorSearchingFilesystem("modules, plots, or formulas", e2)
 				return

--- a/pkg/dab/find_test.go
+++ b/pkg/dab/find_test.go
@@ -1,15 +1,19 @@
 package dab
 
 import (
+	"context"
 	"io/fs"
 	"math/rand"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"testing/fstest"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
+
+	"github.com/warptools/warpforge/pkg/testutil/turtletb"
 	"github.com/warptools/warpforge/wfapi"
 )
 
@@ -28,7 +32,7 @@ var (
 	FormulaData = MustMarshal(&wfapi.Formula{Action: wfapi.Action{Echo: &wfapi.Action_Echo{}}}, "Formula")
 )
 
-const Mode = 0444
+const testDefaultMode = 0444
 
 // randIrregular returns a fs.FileMode from modes in fs.ModeType except for ModeSymlink because stat/open will follow links
 func randIrregular() fs.FileMode {
@@ -37,175 +41,256 @@ func randIrregular() fs.FileMode {
 	return modes[n]
 }
 
-func TestFindActionableFromFS_NotFound(t *testing.T) {
-	t.Run("when no actionable files exist", func(t *testing.T) {
-		fsys := fstest.MapFS{}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "non/existing/directory", true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, path, qt.Equals, "")
-		qt.Assert(t, rem, qt.Equals, "")
-	})
-	t.Run("when actionable files exist above basis directory and searchUp is true", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode, Data: ModuleData},
-			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode, Data: PlotData},
-			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode, Data: FormulaData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "foo/bar", "non/existing/directory", true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, path, qt.Equals, "")
-		qt.Assert(t, rem, qt.Equals, "")
-	})
-	t.Run("when actionable files exist above search directory and searchUp is false", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode, Data: ModuleData},
-			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode, Data: PlotData},
-			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode, Data: FormulaData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "foo/bar", false, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, path, qt.Equals, "")
-		qt.Assert(t, rem, qt.Equals, "foo")
-	})
-	t.Run("when direct file is not regular", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode | randIrregular(), Data: ModuleData},
-			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode | randIrregular(), Data: PlotData},
-			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode | randIrregular(), Data: FormulaData},
-		}
-		for path := range fsys {
-			path := path
-			name := filepath.Base(path)
-			t.Run(name, func(t *testing.T) {
-				// search Up must be false for this test otherwise it will open via *FromFile
-				m, p, f, path, rem, err := FindActionableFromFS(fsys, "", path, false, ActionableSearch_Any)
-				qt.Assert(t, err, qt.IsNil)
-				qt.Assert(t, m, qt.IsNil)
-				qt.Assert(t, p, qt.IsNil)
-				qt.Assert(t, f, qt.IsNil)
-				qt.Assert(t, path, qt.Equals, "")
-				qt.Assert(t, rem, qt.Equals, "foo")
-			})
-		}
-	})
+type fafsInput struct {
+	fs.FS
+	basis    string
+	search   string
+	searchUp bool
+	mode     ActionableSearch
 }
+
+type fafsOutput struct {
+	expectFailure []turtletb.Record // Value will be a regex pattern to match
+	panicPattern  string
+	module        bool
+	plot          bool
+	formula       bool
+	path          string
+	remain        string
+	error         bool
+}
+
+type testcaseFindActionableFromFS struct {
+	name    string
+	inputs  fafsInput
+	outputs fafsOutput
+}
+
+func (tt *testcaseFindActionableFromFS) run(t *testing.T) {
+	in := tt.inputs
+	fsys := in.FS
+	if fsys == nil {
+		fsys = fstest.MapFS{}
+	}
+	if len(tt.outputs.panicPattern) > 0 {
+		qt.Assert(t, func() {
+			FindActionableFromFS(fsys, in.basis, in.search, in.searchUp, in.mode)
+		}, qt.PanicMatches, tt.outputs.panicPattern)
+		t.Skipf("expected panic caught")
+	}
+	m, p, f, path, rem, err := FindActionableFromFS(fsys, in.basis, in.search, in.searchUp, in.mode)
+	isNotNil := func(b bool) qt.Checker {
+		if b {
+			return qt.IsNotNil
+		}
+		return qt.IsNil
+	}
+	out := tt.outputs
+
+	doAssertions := func(t testing.TB) {
+		qt.Assert(t, err, isNotNil(out.error))
+		qt.Assert(t, m, isNotNil(out.module))
+		qt.Assert(t, p, isNotNil(out.plot))
+		qt.Assert(t, f, isNotNil(out.formula))
+		qt.Assert(t, path, qt.Equals, out.path)
+		qt.Assert(t, rem, qt.Equals, out.remain)
+	}
+	if len(out.expectFailure) > 0 {
+		tb := turtletb.TB{TB: t}
+		ctx := context.Background()
+		ctx = tb.Start(ctx, doAssertions)
+		<-ctx.Done()
+		for _, expect := range out.expectFailure {
+			found := false
+			re, err := regexp.Compile(expect.Value)
+			qt.Assert(t, err, qt.IsNil, qt.Commentf("expected failure pattern must compile: %s", expect.Value))
+			for _, r := range tb.Records {
+				if expect.Kind&r.Kind == 0 {
+					// record is not an expected kind
+					continue
+				}
+				if re.MatchString(r.Value) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("Expected test to produce %q record matching %q but did not", expect.Kind, expect.Value)
+			}
+		}
+		qt.Assert(t, tb.Failed(), qt.IsTrue, qt.Commentf("test is expected to fail but did not"))
+		return
+	}
+	doAssertions(t)
+}
+
+type testfsOpt func(m fstest.MapFS) fstest.MapFS
+
+func testFSRandIrregularMode(m fstest.MapFS) fstest.MapFS {
+	for k, v := range m {
+		v.Mode = testDefaultMode | randIrregular()
+		m[k] = v
+	}
+	return m
+}
+
+func newtestFS(basis string, files []string, opts ...testfsOpt) fstest.MapFS {
+	fsys := fstest.MapFS{}
+	data := func(f string) []byte {
+		switch f {
+		case MagicFilename_Module:
+			return ModuleData
+		case MagicFilename_Plot:
+			return PlotData
+		case MagicFilename_Formula:
+			return FormulaData
+		}
+		return []byte{}
+	}
+	for _, f := range files {
+		fsys[filepath.Join(basis, f)] = &fstest.MapFile{Mode: testDefaultMode, Data: data(f)}
+	}
+	for _, o := range opts {
+		fsys = o(fsys)
+	}
+	return fsys
+}
+
+func merge[K comparable, V any](maps ...map[K]V) map[K]V {
+	size := 0
+	for _, m := range maps {
+		size += len(m)
+	}
+	r := make(map[K]V, size)
+	for _, m := range maps {
+		for k, v := range m {
+			r[k] = v
+		}
+	}
+	return r
+}
+
+func TestFindActionableFromFS_NotFound(t *testing.T) {
+	fsMPF := newtestFS("foo", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula})
+	fsIrregularMPF := newtestFS("foo", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula}, testFSRandIrregularMode)
+	for _, tt := range []testcaseFindActionableFromFS{
+		{name: "when no actionable files exist",
+			inputs:  fafsInput{basis: "", search: "non/existing/directory", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "", error: false},
+		},
+		{name: "when actionable files exist above basis directory and searchUp is true",
+			inputs:  fafsInput{FS: fsMPF, basis: "foo/bar", search: "non/existing/directory", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "", error: false},
+		},
+		{name: "when actionable files exist above search directory and searchUp is false",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "foo/bar", searchUp: false, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "foo", error: false},
+		},
+		{name: "when direct file is not regular; module",
+			inputs:  fafsInput{FS: fsIrregularMPF, basis: "", search: "foo/module.wf", searchUp: false, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "foo", error: false},
+		},
+		{name: "when direct file is not regular; plot",
+			inputs:  fafsInput{FS: fsIrregularMPF, basis: "", search: "foo/plot.wf", searchUp: false, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "foo", error: false},
+		},
+		{name: "when direct file is not regular; formula",
+			inputs:  fafsInput{FS: fsIrregularMPF, basis: "", search: "foo/formula.wf", searchUp: false, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: false, formula: false, path: "", remain: "foo", error: false},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, tt.run)
+	}
+}
+
+// formulaNotImplementedError is used to check for the expected error caused by formula loading not being implemented
+var formulaNotImplementedError = []turtletb.Record{{Kind: turtletb.RK_Error, Value: `(?m)got:\s*\(\*wfapi\.Formula\)\(nil\)\s*stack`}}
 
 // test the priority order of FindActionableFromFS
 // module > plot > formula
 // Also tests behavior where the files exist in the filesystem root directory.
 func TestFindActionableFromFS_Priority(t *testing.T) {
-	t.Run("highest", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			MagicFilename_Module:  &fstest.MapFile{Mode: Mode, Data: ModuleData},
-			MagicFilename_Plot:    &fstest.MapFile{Mode: Mode, Data: PlotData},
-			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNotNil)
-		qt.Assert(t, p, qt.IsNotNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, path, qt.Equals, MagicFilename_Module)
-		qt.Assert(t, rem, qt.Equals, "")
-	})
-	t.Run("mid", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			MagicFilename_Plot:    &fstest.MapFile{Mode: Mode, Data: PlotData},
-			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNotNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, path, qt.Equals, MagicFilename_Plot)
-		qt.Assert(t, rem, qt.Equals, "")
-	})
-	t.Run("low", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.Not(qt.IsNotNil))                         // TODO: formula loading not implemented
-		qt.Assert(t, path, qt.Not(qt.Equals), MagicFilename_Formula) // TODO: formula loading not implemented
-		qt.Assert(t, rem, qt.Equals, "")
-	})
+	fsMPF := newtestFS("", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula})
+	fsPF := newtestFS("", []string{MagicFilename_Plot, MagicFilename_Formula})
+	fsF := newtestFS("", []string{MagicFilename_Formula})
+	for _, tt := range []testcaseFindActionableFromFS{
+		{name: "highest",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: MagicFilename_Module, remain: "", error: false},
+		},
+		{name: "mid",
+			inputs:  fafsInput{FS: fsPF, basis: "", search: "", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: true, formula: false, path: MagicFilename_Plot, remain: "", error: false},
+		},
+		{name: "low",
+			inputs: fafsInput{FS: fsF, basis: "", search: "", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{expectFailure: formulaNotImplementedError, // "FIXME: formula loading is not implemented",
+				module: false, plot: false, formula: true, path: MagicFilename_Formula, remain: "", error: false},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, tt.run)
+	}
 }
 
-func TestFindActionableFromFS_DirectFile(t *testing.T) {
-	basePath := "path/to/files"
-	modulePath := filepath.Join(basePath, MagicFilename_Module)
-	plotPath := filepath.Join(basePath, MagicFilename_Plot)
-	frmPath := filepath.Join(basePath, MagicFilename_Formula)
-	fsys := fstest.MapFS{
-		modulePath: &fstest.MapFile{Mode: Mode, Data: ModuleData},
-		plotPath:   &fstest.MapFile{Mode: Mode, Data: PlotData},
-		frmPath:    &fstest.MapFile{Mode: Mode, Data: FormulaData},
-	}
-	t.Run("module with plot", func(t *testing.T) {
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", modulePath, true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNotNil)
-		qt.Assert(t, p, qt.IsNotNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
-		qt.Assert(t, path, qt.Equals, modulePath)
-	})
-	t.Run("module no plot", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			modulePath: &fstest.MapFile{Mode: Mode, Data: ModuleData},
-		}
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", modulePath, true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNotNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
-		qt.Assert(t, path, qt.Equals, modulePath)
-	})
-	t.Run("plot", func(t *testing.T) {
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", plotPath, true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNotNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, rem, qt.Equals, filepath.Dir(plotPath))
-		qt.Assert(t, path, qt.Equals, plotPath)
-	})
-	t.Run("formula", func(t *testing.T) {
-		qt.Assert(t, func() {
-			FindActionableFromFS(fsys, "", frmPath, true, ActionableSearch_Any)
-		}, qt.PanicMatches, "unreachable")
-		t.Skipf("TODO: unimplemented")
+func TestFindActionableFromFS(t *testing.T) {
+	fsRootMPF := newtestFS("", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula})
+	fsParentMPF := newtestFS("path", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula})
+	fsMPF := newtestFS("path/to/files", []string{MagicFilename_Module, MagicFilename_Plot, MagicFilename_Formula})
+	fsMPF = merge(fsMPF, fsRootMPF, fsParentMPF) // merge these to test that we get the correct one
+	fsMF := newtestFS("path/to/files", []string{MagicFilename_Module, MagicFilename_Formula})
 
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", frmPath, true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNil)
-		qt.Assert(t, p, qt.IsNil)
-		qt.Assert(t, f, qt.IsNotNil)
-		qt.Assert(t, rem, qt.Equals, filepath.Dir(frmPath))
-		qt.Assert(t, path, qt.Equals, frmPath)
-	})
-	t.Run("module missing; search up", func(t *testing.T) {
-		searchPath := filepath.Join(filepath.Dir(modulePath), "subdir", MagicFilename_Module)
-		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", searchPath, true, ActionableSearch_Any)
-		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, m, qt.IsNotNil)
-		qt.Assert(t, p, qt.IsNotNil)
-		qt.Assert(t, f, qt.IsNil)
-		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
-		qt.Assert(t, path, qt.Equals, modulePath)
-	})
+	for _, tt := range []testcaseFindActionableFromFS{
+		{name: "direct module with plot",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "path/to/files/module.wf", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "path/to/files", error: false},
+		},
+		{name: "direct module without plot",
+			inputs:  fafsInput{FS: fsMF, basis: "", search: "path/to/files/module.wf", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: false, formula: false, path: "path/to/files/module.wf", remain: "path/to/files", error: false},
+		},
+		{name: "direct plot",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "path/to/files/plot.wf", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: false, plot: true, formula: false, path: "path/to/files/plot.wf", remain: "path/to/files", error: false},
+		},
+		{name: "direct formula",
+			inputs: fafsInput{FS: fsMPF, basis: "", search: "path/to/files/formula.wf", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{
+				panicPattern: "unreachable", // FIXME: formula loading is not implemented
+				module:       false, plot: false, formula: true, path: "path/to/files/formula.wf", remain: "path/to/files", error: false},
+		},
+		{name: "find module in parent directories when search path is a direct file",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "path/to/files/subdir/module.wf", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "path/to/files", error: false},
+		},
+		{name: "find module and plot when search contains trailing slash",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "path/to/files/subdir/", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "path/to/files", error: false},
+		},
+		{name: "find module and plot with exact search path",
+			inputs:  fafsInput{FS: fsMPF, basis: "", search: "path/to/files", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "path/to/files", error: false},
+		},
+		{name: "find module and plot with exact basis path",
+			inputs:  fafsInput{FS: fsMPF, basis: "path/to/files", search: "", searchUp: true, mode: ActionableSearch_Any},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "", error: false},
+		},
+		{name: "find module and plot with only module filter",
+			inputs:  fafsInput{FS: fsMPF, basis: "path/to/files", search: "", searchUp: true, mode: ActionableSearch_Module},
+			outputs: fafsOutput{module: true, plot: true, formula: false, path: "path/to/files/module.wf", remain: "", error: false},
+		},
+		{name: "find plot with filter",
+			inputs:  fafsInput{FS: fsMPF, basis: "path/to/files", search: "", searchUp: true, mode: ActionableSearch_Plot},
+			outputs: fafsOutput{module: false, plot: true, formula: false, path: "path/to/files/plot.wf", remain: "", error: false},
+		},
+		{name: "find formula with filter",
+			inputs: fafsInput{FS: fsMPF, basis: "path/to/files", search: "", searchUp: true, mode: ActionableSearch_Formula},
+			outputs: fafsOutput{expectFailure: formulaNotImplementedError, // "FIXME: formula loading is not implemented",
+				module: false, plot: false, formula: true, path: "path/to/files/formula.wf", remain: "", error: false},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, tt.run)
+	}
 }

--- a/pkg/dab/find_test.go
+++ b/pkg/dab/find_test.go
@@ -1,0 +1,211 @@
+package dab
+
+import (
+	"io/fs"
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/json"
+	"github.com/warptools/warpforge/wfapi"
+)
+
+func MustMarshal(i interface{}, typeName string) []byte {
+	data, err := ipld.Marshal(json.Encode, i, wfapi.TypeSystem.TypeByName(typeName))
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// Data blocks required for "GuessDocumentType"
+var (
+	ModuleData  = MustMarshal(&wfapi.ModuleCapsule{Module: &wfapi.Module{Name: "hello"}}, "ModuleCapsule")
+	PlotData    = MustMarshal(&wfapi.PlotCapsule{Plot: &wfapi.Plot{}}, "PlotCapsule")
+	FormulaData = MustMarshal(&wfapi.Formula{Action: wfapi.Action{Echo: &wfapi.Action_Echo{}}}, "Formula")
+)
+
+const Mode = 0444
+
+// randIrregular returns a fs.FileMode from modes in fs.ModeType except for ModeSymlink because stat/open will follow links
+func randIrregular() fs.FileMode {
+	modes := []fs.FileMode{fs.ModeDir, fs.ModeSymlink, fs.ModeNamedPipe, fs.ModeSocket, fs.ModeDevice, fs.ModeCharDevice, fs.ModeIrregular}
+	n := rand.Intn(len(modes))
+	return modes[n]
+}
+
+func TestFindActionableFromFS_NotFound(t *testing.T) {
+	t.Run("when no actionable files exist", func(t *testing.T) {
+		fsys := fstest.MapFS{}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "non/existing/directory", true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, path, qt.Equals, "")
+		qt.Assert(t, rem, qt.Equals, "")
+	})
+	t.Run("when actionable files exist above basis directory and searchUp is true", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode, Data: ModuleData},
+			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode, Data: PlotData},
+			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode, Data: FormulaData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "foo/bar", "non/existing/directory", true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, path, qt.Equals, "")
+		qt.Assert(t, rem, qt.Equals, "")
+	})
+	t.Run("when actionable files exist above search directory and searchUp is false", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode, Data: ModuleData},
+			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode, Data: PlotData},
+			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode, Data: FormulaData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "foo/bar", false, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, path, qt.Equals, "")
+		qt.Assert(t, rem, qt.Equals, "foo")
+	})
+	t.Run("when direct file is not regular", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			filepath.Join("foo", MagicFilename_Module):  &fstest.MapFile{Mode: Mode | randIrregular(), Data: ModuleData},
+			filepath.Join("foo", MagicFilename_Plot):    &fstest.MapFile{Mode: Mode | randIrregular(), Data: PlotData},
+			filepath.Join("foo", MagicFilename_Formula): &fstest.MapFile{Mode: Mode | randIrregular(), Data: FormulaData},
+		}
+		for path := range fsys {
+			path := path
+			name := filepath.Base(path)
+			t.Run(name, func(t *testing.T) {
+				// search Up must be false for this test otherwise it will open via *FromFile
+				m, p, f, path, rem, err := FindActionableFromFS(fsys, "", path, false, ActionableSearch_Any)
+				qt.Assert(t, err, qt.IsNil)
+				qt.Assert(t, m, qt.IsNil)
+				qt.Assert(t, p, qt.IsNil)
+				qt.Assert(t, f, qt.IsNil)
+				qt.Assert(t, path, qt.Equals, "")
+				qt.Assert(t, rem, qt.Equals, "foo")
+			})
+		}
+	})
+}
+
+// test the priority order of FindActionableFromFS
+// module > plot > formula
+// Also tests behavior where the files exist in the filesystem root directory.
+func TestFindActionableFromFS_Priority(t *testing.T) {
+	t.Run("highest", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			MagicFilename_Module:  &fstest.MapFile{Mode: Mode, Data: ModuleData},
+			MagicFilename_Plot:    &fstest.MapFile{Mode: Mode, Data: PlotData},
+			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNotNil)
+		qt.Assert(t, p, qt.IsNotNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, path, qt.Equals, MagicFilename_Module)
+		qt.Assert(t, rem, qt.Equals, "")
+	})
+	t.Run("mid", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			MagicFilename_Plot:    &fstest.MapFile{Mode: Mode, Data: PlotData},
+			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNotNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, path, qt.Equals, MagicFilename_Plot)
+		qt.Assert(t, rem, qt.Equals, "")
+	})
+	t.Run("low", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			MagicFilename_Formula: &fstest.MapFile{Mode: Mode, Data: FormulaData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", "", false, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.Not(qt.IsNotNil))                         // TODO: formula loading not implemented
+		qt.Assert(t, path, qt.Not(qt.Equals), MagicFilename_Formula) // TODO: formula loading not implemented
+		qt.Assert(t, rem, qt.Equals, "")
+	})
+}
+
+func TestFindActionableFromFS_DirectFile(t *testing.T) {
+	basePath := "path/to/files"
+	modulePath := filepath.Join(basePath, MagicFilename_Module)
+	plotPath := filepath.Join(basePath, MagicFilename_Plot)
+	frmPath := filepath.Join(basePath, MagicFilename_Formula)
+	fsys := fstest.MapFS{
+		modulePath: &fstest.MapFile{Mode: Mode, Data: ModuleData},
+		plotPath:   &fstest.MapFile{Mode: Mode, Data: PlotData},
+		frmPath:    &fstest.MapFile{Mode: Mode, Data: FormulaData},
+	}
+	t.Run("module with plot", func(t *testing.T) {
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", modulePath, true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNotNil)
+		qt.Assert(t, p, qt.IsNotNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
+		qt.Assert(t, path, qt.Equals, modulePath)
+	})
+	t.Run("module no plot", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			modulePath: &fstest.MapFile{Mode: Mode, Data: ModuleData},
+		}
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", modulePath, true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNotNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
+		qt.Assert(t, path, qt.Equals, modulePath)
+	})
+	t.Run("plot", func(t *testing.T) {
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", plotPath, true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNotNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, rem, qt.Equals, filepath.Dir(plotPath))
+		qt.Assert(t, path, qt.Equals, plotPath)
+	})
+	t.Run("formula", func(t *testing.T) {
+		qt.Assert(t, func() {
+			FindActionableFromFS(fsys, "", frmPath, true, ActionableSearch_Any)
+		}, qt.PanicMatches, "unreachable")
+		t.Skipf("TODO: unimplemented")
+
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", frmPath, true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNil)
+		qt.Assert(t, p, qt.IsNil)
+		qt.Assert(t, f, qt.IsNotNil)
+		qt.Assert(t, rem, qt.Equals, filepath.Dir(frmPath))
+		qt.Assert(t, path, qt.Equals, frmPath)
+	})
+	t.Run("module missing; search up", func(t *testing.T) {
+		searchPath := filepath.Join(filepath.Dir(modulePath), "subdir", MagicFilename_Module)
+		m, p, f, path, rem, err := FindActionableFromFS(fsys, "", searchPath, true, ActionableSearch_Any)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, m, qt.IsNotNil)
+		qt.Assert(t, p, qt.IsNotNil)
+		qt.Assert(t, f, qt.IsNil)
+		qt.Assert(t, rem, qt.Equals, filepath.Dir(modulePath))
+		qt.Assert(t, path, qt.Equals, modulePath)
+	})
+}

--- a/pkg/dab/guess.go
+++ b/pkg/dab/guess.go
@@ -48,7 +48,7 @@ func GuessDocumentType(scanMe []byte, keywords []string) (string, error) {
 	// However, a good codec API to accomplish this task efficiently must support token stepping,
 	// because we want to return after a few tokens rather than the whole stream
 	// (and perhaps to be really optimal, it would be nice to even be able to return a buffer of the tokens and a codec that can be resumed).
-	// Regretably, `codec ipld.Decoder` does not expose support for token stepping;
+	// Regrettably, `codec ipld.Decoder` does not expose support for token stepping;
 	// and though the refmt code they're based on does support token stepping, that's polevaulting quite a few layers
 	// (and would not be able to replay any buffered tokens into the ipld.Decoder interface again, either).
 	//

--- a/pkg/dab/guess.go
+++ b/pkg/dab/guess.go
@@ -1,0 +1,80 @@
+package dab
+
+import (
+	"bytes"
+
+	"github.com/serum-errors/go-serum"
+
+	"github.com/warptools/warpforge/wfapi"
+)
+
+// GuessDocumentType peeks into some serial data for the first string token,
+// and looks to see if matches one of the keywords, and returns that string.
+//
+// This is useful if you want to figure out which kind of document a file contains,
+// and they are using some sort of reasonable capsule types so that they resemble:
+//
+//   {"foo":{...}}
+//     or
+//   {"bar.v1":{...}}
+//     or
+//   {"bar.v2":{...}}
+//
+// (This is roughly the data format that an IPLD union type with keyed representation will produce,
+// and that is the usual way we demarcate things in all of the warpforge APIs.)
+//
+// If one of the keywords is found, that string and nil are returned.
+// If the document fails to be parsed in some way, empty string and an error are returned.
+// If the document seemed to be parsable, but none of the keywords are found,
+// empty string and a nil error are returned.
+//
+// This function is restricted to working on JSON,
+// and also on strings that don't require quoting or escaping.
+// See implementation notes in comments in the function body for possible future work.
+//
+// A typically effective way to get the byte slice for scanning is by use
+// of bufio.NewReader followed by Peek on that value.
+// (This leaves that reader overall still ready to feed into a fuller decoder.)
+//
+// Errors:
+//
+//   - warpforge-error-serialization -- if the document is complete unparsable.
+//   - warpforge-error-serialization -- if none of the keywords (or, no strings at all)
+//      can be found within the scan zone.
+func GuessDocumentType(scanMe []byte, keywords []string) (string, error) {
+	// This code takes considerable shortcuts, and is specific to JSON and limited domains of data.
+	//
+	// Ideally, feature would use codecs, and take some kind of codec system as a parameter.
+	// However, a good codec API to accomplish this task efficiently must support token stepping,
+	// because we want to return after a few tokens rather than the whole stream
+	// (and perhaps to be really optimal, it would be nice to even be able to return a buffer of the tokens and a codec that can be resumed).
+	// Regretably, `codec ipld.Decoder` does not expose support for token stepping;
+	// and though the refmt code they're based on does support token stepping, that's polevaulting quite a few layers
+	// (and would not be able to replay any buffered tokens into the ipld.Decoder interface again, either).
+	//
+	// Since we can't get it done within a single consistent abstraction level with any of the APIs we're currently holding for talking about codecs,
+	// instead, this code currently punts in the most intense possible way:
+	// it assumes json, and then some specific simplifications that can be made when looking for the first string in a json document.
+	//
+	// Yes: I'm talking about looking for the first index of a quote character.
+	//
+	// Then we look for the next quote character and also blithely assume escaping is not relevant.
+	// (If your search keywords don't contain such content, then this shakes out to correct.)
+	a := bytes.Index(scanMe, []byte{'"'})
+	if a < 0 {
+		return "", serum.Errorf(wfapi.ECodeSerialization, "cannot detect file type (no markers found within first %d bytes of file)", len(scanMe))
+	}
+	a++
+	b := bytes.Index(scanMe[a:], []byte{'"'})
+	if b < 0 {
+		return "", serum.Errorf(wfapi.ECodeSerialization, "cannot detect file type (no markers found within first %d bytes of file)", len(scanMe))
+	}
+	firstString := string(scanMe[a : a+b])
+	for _, s := range keywords {
+		if s == firstString {
+			return firstString, nil
+		}
+	}
+	return "", nil
+
+}

--- a/pkg/dab/guess_test.go
+++ b/pkg/dab/guess_test.go
@@ -1,0 +1,55 @@
+package dab
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/serum-errors/go-serum"
+
+	"github.com/warptools/warpforge/wfapi"
+)
+
+func TestGuessDocumentType(t *testing.T) {
+	cases := []struct {
+		scanMe        []byte
+		keywords      []string
+		expect        string
+		expectErrCode string
+	}{
+		{ // happy path
+			[]byte(`{"foo":{}}`),
+			[]string{"foo", "bar"},
+			"foo", "",
+		},
+		{ // length edgecases
+			[]byte(``),
+			[]string{"foo", "bar"},
+			"", wfapi.ECodeSerialization,
+		},
+		{ // bad parse (unmatched string delims)
+			[]byte(`"`),
+			[]string{"foo", "bar"},
+			"", wfapi.ECodeSerialization,
+		},
+		{ // empty string edgecase
+			[]byte(`""`),
+			[]string{"foo", "bar"},
+			"", "",
+		},
+		{ // no match
+			[]byte(`"x"`),
+			[]string{"foo", "bar"},
+			"", "",
+		},
+		{ // no match but it does match prefix
+			[]byte(`"foobar"`),
+			[]string{"foo", "bar"},
+			"", "",
+		},
+	}
+	for _, c := range cases {
+		keyword, err := GuessDocumentType(c.scanMe, c.keywords)
+		qt.Check(t, keyword, qt.Equals, c.expect)
+		qt.Check(t, serum.Code(err), qt.Equals, c.expectErrCode)
+	}
+}

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -193,12 +193,16 @@ func validateDNS1123Subdomain(value string) error {
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Module.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
 //  - warpforge-error-module-invalid -- when module name is invalid
+//  - warpforge-error-missing -- when file does not exist
 func ModuleFromFile(fsys fs.FS, filename string) (*wfapi.Module, error) {
 	const situation = "loading a module"
 	if filepath.IsAbs(filename) {
 		filename = filename[1:]
 	}
 	f, err := fs.ReadFile(fsys, filename)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, serum.Error(wfapi.ECodeMissing, serum.WithCause(err))
+	}
 	if err != nil {
 		return nil, wfapi.ErrorIo(situation, filename, err)
 	}
@@ -229,6 +233,7 @@ func ModuleFromFile(fsys fs.FS, filename string) (*wfapi.Module, error) {
 // 	- warpforge-error-io -- for errors reading from fsys.
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Plot.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
+//  - warpforge-error-missing -- when file does not exist
 func PlotFromFile(fsys fs.FS, filename string) (*wfapi.Plot, error) {
 	const situation = "loading a plot"
 
@@ -236,6 +241,9 @@ func PlotFromFile(fsys fs.FS, filename string) (*wfapi.Plot, error) {
 		filename = filename[1:]
 	}
 	f, err := fs.ReadFile(fsys, filename)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, serum.Error(wfapi.ECodeMissing, serum.WithCause(err))
+	}
 	if err != nil {
 		return nil, wfapi.ErrorIo(situation, filename, err)
 	}

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -193,31 +193,31 @@ func validateDNS1123Subdomain(value string) error {
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Module.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
 //  - warpforge-error-module-invalid -- when module name is invalid
-func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
+func ModuleFromFile(fsys fs.FS, filename string) (*wfapi.Module, error) {
 	const situation = "loading a module"
 	if filepath.IsAbs(filename) {
 		filename = filename[1:]
 	}
 	f, err := fs.ReadFile(fsys, filename)
 	if err != nil {
-		return wfapi.Module{}, wfapi.ErrorIo(situation, filename, err)
+		return nil, wfapi.ErrorIo(situation, filename, err)
 	}
 
 	moduleCapsule := wfapi.ModuleCapsule{}
 	_, err = ipld.Unmarshal(f, json.Decode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
 	if err != nil {
-		return wfapi.Module{}, wfapi.ErrorSerialization(situation, err)
+		return nil, wfapi.ErrorSerialization(situation, err)
 	}
 	if moduleCapsule.Module == nil {
 		// ... this isn't really reachable.
-		return wfapi.Module{}, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Module in ModuleCapsule"))
+		return nil, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Module in ModuleCapsule"))
 	}
 
 	if err := ValidateModuleName(moduleCapsule.Module.Name); err != nil {
-		return wfapi.Module{}, err
+		return nil, err
 	}
 
-	return *moduleCapsule.Module, nil
+	return moduleCapsule.Module, nil
 }
 
 // PlotFromFile loads a wfapi.Plot from filesystem path.
@@ -229,7 +229,7 @@ func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
 // 	- warpforge-error-io -- for errors reading from fsys.
 // 	- warpforge-error-serialization -- for errors from try to parse the data as a Plot.
 // 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
-func PlotFromFile(fsys fs.FS, filename string) (wfapi.Plot, error) {
+func PlotFromFile(fsys fs.FS, filename string) (*wfapi.Plot, error) {
 	const situation = "loading a plot"
 
 	if filepath.IsAbs(filename) {
@@ -237,20 +237,20 @@ func PlotFromFile(fsys fs.FS, filename string) (wfapi.Plot, error) {
 	}
 	f, err := fs.ReadFile(fsys, filename)
 	if err != nil {
-		return wfapi.Plot{}, wfapi.ErrorIo(situation, filename, err)
+		return nil, wfapi.ErrorIo(situation, filename, err)
 	}
 
 	plotCapsule := wfapi.PlotCapsule{}
 	_, err = ipld.Unmarshal(f, json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 	if err != nil {
-		return wfapi.Plot{}, wfapi.ErrorSerialization(situation, err)
+		return nil, wfapi.ErrorSerialization(situation, err)
 	}
 	if plotCapsule.Plot == nil {
 		// ... this isn't really reachable.
-		return wfapi.Plot{}, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Plot in PlotCapsule"))
+		return nil, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Plot in PlotCapsule"))
 	}
 
-	return *plotCapsule.Plot, nil
+	return plotCapsule.Plot, nil
 }
 
 func dirNoDot(path string) string {

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -378,7 +378,7 @@ func exec(ctx context.Context, pltCfg wfapi.PlotExecConfig, modulePathAbs string
 		return result, err
 	}
 	exCfg.WorkingDirectory = moduleDirAbs
-	result, err = plotexec.Exec(ctx, exCfg, wss, wfapi.PlotCapsule{Plot: &plot}, pltCfg)
+	result, err = plotexec.Exec(ctx, exCfg, wss, wfapi.PlotCapsule{Plot: plot}, pltCfg)
 
 	if err != nil {
 		return result, wfapi.ErrorPlotExecutionFailed(err)

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -130,7 +130,7 @@ func canonicalizePath(pwd, path string) string {
 }
 
 // getIngests returns all the "git ingest" inputs used in a plot.
-func getIngests(plot wfapi.Plot) map[string]string {
+func getIngests(plot *wfapi.Plot) map[string]string {
 	ingests := make(map[string]string)
 	var allInputs []wfapi.PlotInput
 	for _, input := range plot.Inputs.Values {
@@ -165,6 +165,7 @@ func getIngests(plot wfapi.Plot) map[string]string {
 //    - warpforge-error-unknown -- when changing directories fails
 //    - warpforge-error-unknown -- when context ends for reasons other than being canceled
 //    - warpforge-error-workspace-missing -- workspace not found
+//    - warpforge-error-missing -- when a required file is missing
 func (c *Config) Run(ctx context.Context) error {
 	log := logging.Ctx(ctx)
 	searchPath := canonicalizePath(c.WorkingDirectory, c.Path)
@@ -352,6 +353,11 @@ func (c *Config) Run(ctx context.Context) error {
 //    - warpforge-error-searching-filesystem -- when finding workspace stack fails
 //    - warpforge-error-serialization -- when the module or plot cannot be parsed
 //    - warpforge-error-workspace-missing -- when opening the workspace set fails
+//    - warpforge-error-module-invalid -- when module name is invalid
+//    - warpforge-error-datatoonew -- module or plot contains newer-than-recognized versions
+//    - warpforge-error-searching-filesystem -- when an unexpected error occurs traversing the search path
+//    - warpforge-error-initialization -- when working directory or binary path cannot be found
+//    - warpforge-error-missing -- when a required file is missing
 func exec(ctx context.Context, pltCfg wfapi.PlotExecConfig, modulePathAbs string) (wfapi.PlotResults, error) {
 	ctx, span := tracing.Start(ctx, "execModule")
 	defer span.End()

--- a/pkg/testutil/turtletb/tb.go
+++ b/pkg/testutil/turtletb/tb.go
@@ -1,0 +1,199 @@
+// TurtleTB creates an implementation of TB that is more inspectable.
+// May be used where failures are expected.
+// Why "turtletb"? Because "tb" is too short for a package name and is a commonly used variable string. I couldn't think of anything good. It's turtles all the way down.
+package turtletb
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+var _ testing.TB = &TB{}
+
+// TB is a very simplified implementation of testing.TB
+// Some functions rely on a "parent" implementation.
+// Particularly "Helper" must be implemented by the parent.
+//
+// Use "Start" to run tests within a goroutine that will exit on failure.
+type TB struct {
+	testing.TB
+	ctx     context.Context
+	failed  bool
+	skipped bool
+	Records []Record // Stores logs for later inspection. Any calls to Log/Error/Skip which takes inputs to log will end up in here as well as logged to the parent TB.
+}
+
+type RecordKind int
+
+const (
+	RK_Log RecordKind = 1 << iota
+	RK_Error
+	RK_Skip
+)
+
+type Record struct {
+	Kind  RecordKind // RecordKind is a bitfield which allows easy filtering
+	Value string
+}
+
+// Start will create a goroutine which runs the function
+func (tb *TB) Start(ctx context.Context, f func(testing.TB)) context.Context {
+	if tb.ctx != nil {
+		panic("tb: TB instance already started")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer cancel()
+		f(tb)
+	}()
+	return ctx
+}
+
+func (tb *TB) record(kind RecordKind, args ...any) {
+	r := Record{Kind: kind, Value: fmt.Sprint(args...)}
+	tb.Records = append(tb.Records, r)
+	if tb.TB != nil {
+		tb.TB.Helper()
+		tb.TB.Log(args...)
+	}
+}
+
+func (tb *TB) recordf(kind RecordKind, format string, args ...any) {
+	r := Record{Kind: kind, Value: fmt.Sprintf(format, args...)}
+	tb.Records = append(tb.Records, r)
+	if tb.TB != nil {
+		tb.TB.Helper()
+		tb.TB.Logf(format, args...)
+	}
+}
+
+// Cleanup implements testing.TB
+func (tb *TB) Cleanup(f func()) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.TB.Cleanup(f)
+}
+
+// Error implements testing.TB
+func (tb *TB) Error(args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.record(RK_Error, args...)
+	tb.Fail()
+}
+
+// Errorf implements testing.TB
+func (tb *TB) Errorf(format string, args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.recordf(RK_Error, format, args...)
+	tb.Fail()
+}
+
+// Fail implements testing.TB
+func (tb *TB) Fail() {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.failed = true
+}
+
+// FailNow implements testing.TB
+func (tb *TB) FailNow() {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.Fail()
+	runtime.Goexit()
+}
+
+// Failed implements testing.TB
+func (tb *TB) Failed() bool {
+	return tb.failed
+}
+
+// Fatal implements testing.TB
+func (tb *TB) Fatal(args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.Error(args...)
+	tb.FailNow()
+}
+
+// Fatalf implements testing.TB
+func (tb *TB) Fatalf(format string, args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.Errorf(format, args...)
+	tb.FailNow()
+}
+
+// Log implements testing.TB
+func (tb *TB) Log(args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.record(RK_Log, args...)
+}
+
+// Logf implements testing.TB
+func (tb *TB) Logf(format string, args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.recordf(RK_Log, format, args...)
+}
+
+// Name implements testing.TB
+func (tb *TB) Name() string {
+	return tb.TB.Name()
+}
+
+// Setenv implements testing.TB
+func (tb *TB) Setenv(key string, value string) {
+	tb.TB.Setenv(key, value)
+}
+
+// Skip implements testing.TB
+func (tb *TB) Skip(args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.record(RK_Skip, args...)
+	tb.SkipNow()
+}
+
+// SkipNow implements testing.TB
+func (tb *TB) SkipNow() {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.skipped = true
+	runtime.Goexit()
+}
+
+// Skipf implements testing.TB
+func (tb *TB) Skipf(format string, args ...any) {
+	if tb.TB != nil {
+		tb.TB.Helper()
+	}
+	tb.recordf(RK_Skip, format, args...)
+	tb.SkipNow()
+}
+
+// Skipped implements testing.TB
+func (tb *TB) Skipped() bool {
+	return tb.skipped
+}
+
+// TempDir implements testing.TB
+func (tb *TB) TempDir() string {
+	return tb.TB.TempDir()
+}


### PR DESCRIPTION
Makes some changes to how Ferk works:
1. Allows the plot specified to be a plot file or a module directory
2. Modify ferk to run a specific step in the plot (default: `ferk`)

Most notably, this adds `dab.FindActionableFromFS` which finds actionable files (modules, formulas, plots) in a standard way. This is only use by `ferk` as of this PR, but will be integrated into other subcommands (notably, `run`) in the near future :)

