### PR TITLE
add tests and fixes for workspace detection.

### DIFF
--- a/cmd/warpforge/internal/util/util.go
+++ b/cmd/warpforge/internal/util/util.go
@@ -93,7 +93,7 @@ func canonicalizePath(pwd, path string) string {
 //    - warpforge-error-plot-invalid -- when the plot data is invalid
 //    - warpforge-error-plot-step-failed --
 //    - warpforge-error-serialization -- when the module or plot cannot be parsed
-//    - warpforge-error-workspace -- when opening the workspace set fails
+//    - warpforge-error-workspace-missing -- when opening the workspace set fails
 //    - warpforge-error-datatoonew -- when error is too new
 //    - warpforge-error-searching-filesystem -- unexpected error traversing filesystem
 //    - warpforge-error-initialization -- fail to get working directory or executable path

--- a/pkg/plotexec/plot_exec.go
+++ b/pkg/plotexec/plot_exec.go
@@ -80,7 +80,7 @@ func (m pipeMap) lookup(stepName wfapi.StepName, label wfapi.LocalLabel) (*wfapi
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when a replay fails
-//    - warpforge-error-workspace -- when home workspace is missing or cannot open
+//    - warpforge-error-workspace-missing -- when home workspace is missing or cannot open
 func plotInputToFormulaInput(ctx context.Context,
 	cfg ExecConfig,
 	wss workspace.WorkspaceSet,
@@ -122,7 +122,7 @@ func plotInputToFormulaInput(ctx context.Context,
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when a replay fails
-//    - warpforge-error-workspace -- when home workspace is missing or cannot open
+//    - warpforge-error-workspace-missing -- when home workspace is missing or cannot open
 func plotInputToFormulaInputSimple(ctx context.Context,
 	cfg ExecConfig,
 	wss workspace.WorkspaceSet,
@@ -342,7 +342,6 @@ func plotInputToFormulaInputSimple(ctx context.Context,
 //    - warpforge-error-executor-failed -- when the execution step of the formula fails
 //    - warpforge-error-ware-unpack -- when a ware unpack operation fails for a formula input
 //    - warpforge-error-ware-pack -- when a ware pack operation fails for a formula output
-//    - warpforge-error-workspace -- when an invalid workspace is provided
 //    - warpforge-error-formula-invalid -- when an invalid formula is provided
 //    - warpforge-error-git -- when an error handing a git ingest occurs
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
@@ -351,7 +350,7 @@ func plotInputToFormulaInputSimple(ctx context.Context,
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when a replay fails
 //    - warpforge-error-serialization -- when serialization or deserialization of a memo fails
-//    - warpforge-error-workspace -- when home workspace is missing or cannot open
+//    - warpforge-error-workspace-missing -- when home workspace is missing or cannot open
 func execProtoformula(ctx context.Context,
 	cfg ExecConfig,
 	wss workspace.WorkspaceSet,
@@ -412,7 +411,7 @@ func execProtoformula(ctx context.Context,
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when execution of a plot step fails
-//    - warpforge-error-workspace -- when home workspace is missing or cannot be opened
+//    - warpforge-error-workspace-missing -- when home workspace is missing or cannot be opened
 func execPlot(ctx context.Context, cfg ExecConfig, wss workspace.WorkspaceSet, plot wfapi.Plot, pltCfg wfapi.PlotExecConfig) (wfapi.PlotResults, error) {
 	ctx, span := tracing.Start(ctx, "execPlot")
 	defer span.End()
@@ -547,7 +546,7 @@ func execPlot(ctx context.Context, cfg ExecConfig, wss workspace.WorkspaceSet, p
 //    - warpforge-error-io -- when an IO error occurs during conversion
 //    - warpforge-error-plot-invalid -- when the provided plot input is invalid
 //    - warpforge-error-plot-step-failed -- when execution of a plot step fails
-//    - warpforge-error-workspace -- when home workspace is missing or cannot be opened
+//    - warpforge-error-workspace-missing -- when home workspace is missing or cannot be opened
 func Exec(ctx context.Context, cfg ExecConfig, wss workspace.WorkspaceSet, plotCapsule wfapi.PlotCapsule, pltCfg wfapi.PlotExecConfig) (result wfapi.PlotResults, err error) {
 	ctx, span := tracing.StartFn(ctx, "Exec")
 	defer func() { tracing.EndWithStatus(span, err) }()

--- a/pkg/plumbing/watch/watch.go
+++ b/pkg/plumbing/watch/watch.go
@@ -358,11 +358,11 @@ func (c *Config) Run(ctx context.Context) error {
 //    - warpforge-error-plot-invalid -- when the plot data is invalid
 //    - warpforge-error-plot-step-failed --
 //    - warpforge-error-serialization -- when the module or plot cannot be parsed
-//    - warpforge-error-workspace -- when opening the workspace set fails
 //    - warpforge-error-module-invalid -- when module name is invalid
 //    - warpforge-error-datatoonew -- module or plot contains newer-than-recognized versions
 //    - warpforge-error-searching-filesystem -- when an unexpected error occurs traversing the search path
 //    - warpforge-error-initialization -- when working directory or binary path cannot be found
+//    - warpforge-error-workspace-missing -- when opening the workspace set fails
 func exec(ctx context.Context, pltCfg wfapi.PlotExecConfig, modulePathAbs string) (wfapi.PlotResults, error) {
 	ctx, span := tracing.Start(ctx, "execModule")
 	defer span.End()

--- a/pkg/workspace/fsdetect_test.go
+++ b/pkg/workspace/fsdetect_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"io/fs"
+	"os"
 	"testing"
 	"testing/fstest"
 
@@ -10,8 +11,8 @@ import (
 	_ "github.com/warptools/warpforge/pkg/testutil"
 )
 
-// projects out just the paths from a list of workspaces; makes convenient diffables for test results.
-func projectWorkspacePaths(wss []*Workspace) []string {
+// wssRootPaths returns just the paths from a list of workspaces; makes convenient diffables for test results.
+func wssRootPaths(wss []*Workspace) []string {
 	var res []string
 	for _, ws := range wss {
 		_, pth := ws.Path()
@@ -20,122 +21,294 @@ func projectWorkspacePaths(wss []*Workspace) []string {
 	return res
 }
 
-func TestWorkspaceDetection(t *testing.T) {
+func TestHomeDir(t *testing.T) {
+	hd, err := os.UserHomeDir()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, homedir, qt.Equals, hd[1:])
+}
+
+func TestFindWorkspaceStack(t *testing.T) {
 	homedir = "home/user"
-	t.Run("happy-path", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			"home/user/.warphome":                      &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/foobar-proj/.warpforge":         &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/workspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/workspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/workspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-		}
-		// fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		// 	fmt.Printf(":fs: %s -- %#v\n", path, d)
-		// 	return nil
-		// })
-		t.Run("find-returns-workspace", func(t *testing.T) {
-			ws, _, err := FindWorkspace(fsys, "", "home/user/foobar-proj")
-			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, ws, qt.IsNotNil)
-			qt.Check(t, ws.rootPath, qt.Equals, "home/user/foobar-proj")
-		})
-		t.Run("find-returns-workspace-from-subdir", func(t *testing.T) {
-			ws, _, err := FindWorkspace(fsys, "", "home/user/workspace/quux-proj/subdir")
-			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, ws, qt.IsNotNil)
-			qt.Check(t, ws.rootPath, qt.Equals, "home/user/workspace/quux-proj")
-		})
-		t.Run("find-does-not-return-home-workspace", func(t *testing.T) {
-			ws, _, err := FindWorkspace(fsys, "", "home/user")
-			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, ws, qt.IsNil)
-		})
-		t.Run("find-stack-works-in-project", func(t *testing.T) {
+
+	t.Run("with home as default root workspace", func(t *testing.T) {
+		t.Run("returns single+home workspace", func(t *testing.T) {
+			fsys := fstest.MapFS{
+				"home/user/foobar-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				"home/user/.warphome":              &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				"home/user/.warphome/root":         &fstest.MapFile{Mode: 0755},
+			}
 			wss, err := FindWorkspaceStack(fsys, "", "home/user/foobar-proj")
 			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, projectWorkspacePaths(wss), qt.DeepEquals, []string{
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
 				"home/user/foobar-proj",
 				"home/user",
 			})
 			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
 			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
 		})
-		t.Run("find-stack-works-in-nested-project", func(t *testing.T) {
-			wss, err := FindWorkspaceStack(fsys, "", "home/user/workspace/quux-proj")
+		t.Run("returns single+non-existent home workspace", func(t *testing.T) {
+			fsys := fstest.MapFS{
+				"home/user/foobar-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			}
+			wss, err := FindWorkspaceStack(fsys, "", "home/user/foobar-proj")
 			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, projectWorkspacePaths(wss), qt.DeepEquals, []string{
-				"home/user/workspace/quux-proj",
-				"home/user/workspace",
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/foobar-proj",
 				"home/user",
 			})
 			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
 		})
-		t.Run("find-stack-works-in-nested-project-subdir", func(t *testing.T) {
-			wss, err := FindWorkspaceStack(fsys, "", "home/user/workspace/quux-proj/subdir")
+		t.Run("returns nested workspaces", func(t *testing.T) {
+			t.Run("from workspace dir", func(t *testing.T) {
+				fsys := fstest.MapFS{
+					"home/user/yaworkspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				}
+				wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/quux-proj")
+				qt.Check(t, err, qt.IsNil)
+				qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+					"home/user/yaworkspace/quux-proj",
+					"home/user/yaworkspace",
+					"home/user",
+				})
+				qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+
+			})
+			t.Run("from subdir", func(t *testing.T) {
+				fsys := fstest.MapFS{
+					"home/user/yaworkspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				}
+				wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/quux-proj/subdir")
+				qt.Check(t, err, qt.IsNil)
+				qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+					"home/user/yaworkspace/quux-proj",
+					"home/user/yaworkspace",
+					"home/user",
+				})
+				qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			})
+			t.Run("from non-existent subdir", func(t *testing.T) {
+				fsys := fstest.MapFS{
+					"home/user/yaworkspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				}
+				wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/quux-proj/subdir/not-a-real-path")
+				qt.Check(t, err, qt.IsNil)
+				qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+					"home/user/yaworkspace/quux-proj",
+					"home/user/yaworkspace",
+					"home/user",
+				})
+				qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			})
+			t.Run("ignores extra home workspace", func(t *testing.T) {
+				fsys := fstest.MapFS{
+					"home/user/yaworkspace/.warpforge":                   &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/althome/.warphome":            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+					"home/user/yaworkspace/althome/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+				}
+				wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/althome/quux-proj")
+				qt.Check(t, err, qt.IsNil)
+				qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+					"home/user/yaworkspace/althome/quux-proj",
+					"home/user/yaworkspace",
+					"home/user",
+				})
+				qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			})
+		})
+		t.Run("returns workspace at top-level directory", func(t *testing.T) {
+			fsys := fstest.MapFS{
+				".warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			}
+			wss, err := FindWorkspaceStack(fsys, "", "home/user/workspace/quux-proj/subdir/not-a-real-path")
 			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, projectWorkspacePaths(wss), qt.DeepEquals, []string{
-				"home/user/workspace/quux-proj",
-				"home/user/workspace",
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				".",
 				"home/user",
 			})
 			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
 		})
 	})
-	t.Run("happy-path-with-root-workspace", func(t *testing.T) {
+	t.Run("with root workspace", func(t *testing.T) {
 		fsys := fstest.MapFS{
-			"home/user/.warpforge":                                               &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/yaworkspace/.warpforge":                                   &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/yaworkspace/rootworkspace/.warpforge":                     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/yaworkspace/rootworkspace/.warpforge/root":                &fstest.MapFile{Mode: 0755},
-			"home/user/yaworkspace/rootworkspace/workspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/yaworkspace/rootworkspace/workspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/yaworkspace/rootworkspace/workspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/.warpforge":                                            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/.warphome":                                     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/.warpforge/root":                &fstest.MapFile{Mode: 0755},
+			"home/user/yaworkspace/althome/root-workspace/.warpforge":                     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
 		}
-		// fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		// 	fmt.Printf(":fs: %s -- %#v\n", path, d)
-		// 	return nil
-		// })
-		t.Run("find-returns-root-workspace", func(t *testing.T) {
-			ws, _, err := FindWorkspace(fsys, "", "home/user/yaworkspace/rootworkspace")
+		t.Run("returns nested workspaces", func(t *testing.T) {
+			wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/althome/root-workspace/workspace/quux-proj")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj",
+				"home/user/yaworkspace/althome/root-workspace/workspace",
+				"home/user/yaworkspace/althome/root-workspace",
+			})
+			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsFalse)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
+		})
+		t.Run("returns nested workspaces from subdir", func(t *testing.T) {
+			wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/althome/root-workspace/workspace/quux-proj/subdir")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj",
+				"home/user/yaworkspace/althome/root-workspace/workspace",
+				"home/user/yaworkspace/althome/root-workspace",
+			})
+			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsFalse)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
+		})
+	})
+	t.Run("with basis path", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"home/user/.warphome/root":                                                    &fstest.MapFile{Mode: 0755},
+			"home/user/.warphome":                                                         &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/.warpforge":                                            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/.warphome/root":                                &fstest.MapFile{Mode: 0755},
+			"home/user/yaworkspace/althome/.warphome":                                     &fstest.MapFile{Mode: 0755 | fs.ModeDir}, // althome exists as a test that we don't detect extra .warphome directories
+			"home/user/yaworkspace/althome/root-workspace/.warpforge/root":                &fstest.MapFile{Mode: 0755},
+			"home/user/yaworkspace/althome/root-workspace/.warpforge":                     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/.warpforge":           &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		t.Run("with no search path, returns basis path if it is a workspace", func(t *testing.T) {
+			wss, err := FindWorkspaceStack(fsys, "home/user/yaworkspace/althome/root-workspace/workspace/quux-proj", "")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, wss, qt.IsNotNil)
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj",
+				"home/user",
+			})
+			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
+		})
+		t.Run("returns multiple workspaces up to and including basis path", func(t *testing.T) {
+			wss, err := FindWorkspaceStack(fsys, "home/user/yaworkspace/althome/root-workspace/workspace", "quux-proj/subdir")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, wss, qt.IsNotNil)
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj",
+				"home/user/yaworkspace/althome/root-workspace/workspace",
+				"home/user",
+			})
+			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsTrue)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
+		})
+		t.Run("returns up to first root workspace", func(t *testing.T) {
+			wss, err := FindWorkspaceStack(fsys, "home/user/yaworkspace", "althome/root-workspace/workspace/quux-proj/subdir")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, wss, qt.IsNotNil)
+			qt.Check(t, wssRootPaths(wss), qt.DeepEquals, []string{
+				"home/user/yaworkspace/althome/root-workspace/workspace/quux-proj",
+				"home/user/yaworkspace/althome/root-workspace/workspace",
+				"home/user/yaworkspace/althome/root-workspace",
+			})
+			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsFalse)
+			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
+		})
+	})
+}
+
+func TestFindWorkspace(t *testing.T) {
+	homedir = "home/user"
+	t.Run("returns workspace", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"workspace/.warpforge":             &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"workspace/foobar-proj":            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"workspace/foobar-proj/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		ws, rem, err := FindWorkspace(fsys, "", "workspace/foobar-proj")
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, ws, qt.IsNotNil)
+		qt.Check(t, ws.rootPath, qt.Equals, "workspace/foobar-proj")
+		qt.Check(t, rem, qt.Equals, "workspace")
+	})
+	t.Run("returns workspace from subdir", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"path/workspace/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"path/workspace/subdir":     &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		ws, rem, err := FindWorkspace(fsys, "", "path/workspace/subdir/non-existent-subdir")
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, ws, qt.IsNotNil)
+		qt.Check(t, ws.rootPath, qt.Equals, "path/workspace")
+		qt.Check(t, rem, qt.Equals, "path")
+	})
+	t.Run("does not return extra home workspace", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"home/user/.warphome":         &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"workspace/.warpforge":        &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"workspace/nothome/.warphome": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		{
+			ws, rem, err := FindWorkspace(fsys, "", "home/user")
+			qt.Check(t, err, qt.IsNil)
+			qt.Check(t, ws, qt.IsNil)
+			qt.Check(t, rem, qt.Equals, "")
+		}
+		{
+			ws, rem, err := FindWorkspace(fsys, "", "workspace/nothome")
 			qt.Check(t, err, qt.IsNil)
 			qt.Assert(t, ws, qt.IsNotNil)
-			qt.Check(t, ws.rootPath, qt.Equals, "home/user/yaworkspace/rootworkspace")
-			qt.Check(t, ws.IsHomeWorkspace(), qt.IsFalse)
-			qt.Check(t, ws.IsRootWorkspace(), qt.IsTrue)
-		})
-		t.Run("find-stack-works-in-nested-project", func(t *testing.T) {
-			wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/rootworkspace/workspace/quux-proj")
-			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, projectWorkspacePaths(wss), qt.DeepEquals, []string{
-				"home/user/yaworkspace/rootworkspace/workspace/quux-proj",
-				"home/user/yaworkspace/rootworkspace/workspace",
-				"home/user/yaworkspace/rootworkspace",
-			})
-			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsFalse)
-			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
-		})
-		t.Run("find-stack-works-in-nested-project-subdir", func(t *testing.T) {
-			wss, err := FindWorkspaceStack(fsys, "", "home/user/yaworkspace/rootworkspace/workspace/quux-proj/subdir")
-			qt.Check(t, err, qt.IsNil)
-			qt.Check(t, projectWorkspacePaths(wss), qt.DeepEquals, []string{
-				"home/user/yaworkspace/rootworkspace/workspace/quux-proj",
-				"home/user/yaworkspace/rootworkspace/workspace",
-				"home/user/yaworkspace/rootworkspace",
-			})
-			qt.Check(t, wss[len(wss)-1].IsHomeWorkspace(), qt.IsFalse)
-			qt.Check(t, wss[len(wss)-1].IsRootWorkspace(), qt.IsTrue)
-		})
-	})
-	t.Run("unhappy-path-workspace-not-a-dir", func(t *testing.T) {
-		fsys := fstest.MapFS{
-			"home/user/foo":            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
-			"home/user/foo/.warpforge": &fstest.MapFile{Mode: 0755},
+			qt.Check(t, ws.rootPath, qt.Equals, "workspace")
+			qt.Check(t, rem, qt.Equals, "")
 		}
-		_, statErr := fs.Stat(fsys, "home/user/foo/.warpforge")
+	})
+	t.Run("returns nothing when workspace internals is a regular file", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"home/user/fake":            &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+			"home/user/fake/.warpforge": &fstest.MapFile{Mode: 0755}, // Explicitly NOT fs.ModeDir
+		}
+		_, statErr := fs.Stat(fsys, "home/user/fake/.warpforge")
 		qt.Check(t, statErr, qt.IsNil)
-		ws, _, err := FindWorkspace(fsys, "", "home/user/foo")
+		ws, rem, err := FindWorkspace(fsys, "", "home/user/fake")
 		qt.Check(t, err, qt.IsNil)
 		qt.Check(t, ws, qt.IsNil)
+		qt.Check(t, rem, qt.Equals, "")
+	})
+	t.Run("returns workspace from top level directory", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			".warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		ws, rem, err := FindWorkspace(fsys, "", "a/path/to/nowhere")
+		qt.Check(t, err, qt.IsNil)
+		qt.Assert(t, ws, qt.IsNotNil)
+		qt.Check(t, rem, qt.Equals, "")
+		qt.Check(t, ws.rootPath, qt.Equals, ".")
+		qt.Check(t, ws.IsHomeWorkspace(), qt.IsFalse)
+		qt.Check(t, ws.IsRootWorkspace(), qt.IsFalse)
+	})
+	t.Run("return workspace when basis path is workspace path", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"workspace/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		ws, rem, err := FindWorkspace(fsys, "workspace", "a/path/to/nowhere")
+		qt.Check(t, err, qt.IsNil)
+		qt.Assert(t, ws, qt.IsNotNil)
+		qt.Check(t, rem, qt.Equals, "")
+		qt.Check(t, ws.rootPath, qt.Equals, "workspace")
+		qt.Check(t, ws.IsHomeWorkspace(), qt.IsFalse)
+		qt.Check(t, ws.IsRootWorkspace(), qt.IsFalse)
+	})
+	t.Run("return workspace when search path repeats basis path ", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"workspace/.warpforge": &fstest.MapFile{Mode: 0755 | fs.ModeDir},
+		}
+		ws, rem, err := FindWorkspace(fsys, "workspace", "workspace/a/path/to/nowhere")
+		qt.Check(t, err, qt.IsNil)
+		qt.Assert(t, ws, qt.IsNotNil)
+		qt.Check(t, rem, qt.Equals, "")
+		qt.Check(t, ws.rootPath, qt.Equals, "workspace")
+		qt.Check(t, ws.IsHomeWorkspace(), qt.IsFalse)
+		qt.Check(t, ws.IsRootWorkspace(), qt.IsFalse)
 	})
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -35,11 +35,11 @@ type Workspace struct {
 //
 // Errors:
 //
-//    - warpforge-error-workspace -- when the workspace directory fails to open
+//    - warpforge-error-workspace-missing -- when the workspace directory does not exist
 func OpenWorkspace(fsys fs.FS, rootPath string) (*Workspace, error) {
-	_, err := statDir(fsys, filepath.Join(rootPath, magicWorkspaceDirname))
+	_, err := statWorkspace(fsys, filepath.Join(rootPath, magicWorkspaceDirname))
 	if err != nil {
-		return nil, wfapi.ErrorWorkspace(rootPath, err)
+		return nil, err
 	}
 	return openWorkspace(fsys, rootPath), nil
 }
@@ -76,13 +76,15 @@ func openHomeWorkspace(fsys fs.FS) *Workspace {
 //
 // Errors:
 //
-//    - warpforge-error-workspace -- when the workspace directory fails to open
+//    - warpforge-error-workspace-missing -- when the workspace directory does not exist
 func OpenHomeWorkspace(fsys fs.FS) (*Workspace, error) {
-	workspace, err := OpenWorkspace(fsys, homedir)
-	if err == nil {
-		workspace.isHomeWorkspace = true
-		workspace.isRootWorkspace = true
+	_, err := statWorkspace(fsys, filepath.Join(homedir, magicHomeWorkspaceDirname))
+	if err != nil {
+		return nil, err
 	}
+	workspace := openHomeWorkspace(fsys)
+	workspace.isHomeWorkspace = true
+	workspace.isRootWorkspace = true
 	return workspace, err
 }
 

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -38,6 +38,7 @@ const (
 	ECodeWareUnpack             = "warpforge-error-ware-unpack"              // ECodeWareUnpack is used when unpacking a ware fails.
 	ECodeWorkspace              = "warpforge-error-workspace"                // ECodeWorkspace is used when an error occurs handling a workspace.
 	ECodeInitialization         = "warpforge-error-initialization"           // ECodeInitialization is used for errors during loading configuration and environment
+	ECodeWorkspaceMissing       = "warpforge-error-workspace-missing"        // ECodeWorkspace is used when an expected workspace does not exist.
 )
 
 // IsCode reports whether any error in err's chain matches the given code string.


### PR DESCRIPTION
This includes a test which finds an edge case which will not halt when executing the old FindWorkspace functions.
The goal here is to exercise the FindWorkspace functions thoroughly so we don't find too many more surprises.


This is split off from #58 to reduce PR size.