### PR TITLE
allow rio to be mounted via symbolic links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ MODULE := $(shell go list -m)
 install:
 	@echo "Installing plugins..."
 	mkdir -p $(GOBIN)
-	cp ./plugins/* $(GOBIN)
+# ignore errors when copying plugins (cp does not like copying over symbolic links)
+	-cp ./plugins/* $(GOBIN)
 	@echo "Building and installing warpforge..."
 	go install ./...
 	@echo "Install complete!"

--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -171,6 +172,7 @@ func containerScriptPath() string {
 }
 
 func getMountDirSymlinks(start string) []string {
+	//FIXME: This function is not implemented in an easily testable way.
 	paths := []string{}
 	path := start
 
@@ -222,15 +224,7 @@ func getNetworkMounts() []specs.Mount {
 			for _, p := range getMountDirSymlinks(path) {
 				dir := filepath.Dir(p)
 
-				// ignore duplicate mounts
-				duplicate := false
-				for _, m := range mounts {
-					if m.Source == dir {
-						duplicate = true
-						break
-					}
-				}
-				if duplicate {
+				if isDuplicateMount(mounts, dir, dir) {
 					continue
 				}
 
@@ -246,6 +240,65 @@ func getNetworkMounts() []specs.Mount {
 	}
 
 	return mounts
+}
+
+// isDuplicateMount returns true if the source or destination is in mounts
+func isDuplicateMount(mounts []specs.Mount, src string, dst string) bool {
+	for _, m := range mounts {
+		if m.Source == src {
+			return true
+		}
+		if m.Destination == dst {
+			return true
+		}
+	}
+	return false
+}
+
+func isSymbolicLink(m fs.FileMode) bool {
+	return m&fs.ModeSymlink == fs.ModeSymlink
+}
+
+func getBinMounts(binPath string) []specs.Mount {
+	wfBinMount := specs.Mount{
+		Source:      binPath,
+		Destination: containerBinPath(),
+		Type:        "none",
+		Options:     []string{"rbind", "ro"},
+	}
+	result := []specs.Mount{wfBinMount}
+	binFiles, err := ioutil.ReadDir(binPath) // note that this doesn't support nested directories.
+	if err != nil {
+		return result
+	}
+	for _, file := range binFiles {
+		if file == nil || !isSymbolicLink(file.Mode()) {
+			continue
+		}
+		path := filepath.Join(binPath, file.Name())
+		dst := wfBinMount.Destination
+		for _, p := range getMountDirSymlinks(path) {
+			src := filepath.Dir(p)
+			k, err := os.Readlink(p)
+			if err != nil || filepath.IsAbs(k) {
+				dst = src
+			} else {
+				dst = filepath.Join(dst, filepath.Dir(k))
+			}
+
+			if isDuplicateMount(result, src, dst) {
+				continue
+			}
+			symMount := specs.Mount{
+				Source:      src,
+				Destination: dst,
+				Type:        "none",
+				Options:     []string{"rbind", "ro"},
+			}
+			result = append(result, symMount)
+		}
+	}
+	return result
 }
 
 // newRuncSpec executes "runc spec" for the given parameters and parses the result
@@ -375,13 +428,9 @@ func (cfg internalConfig) newRuncConfig(ctx context.Context, runPath string, bas
 		}
 		rc.spec.Mounts = append(rc.spec.Mounts, wfWarehouseMount)
 	}
-	wfBinMount := specs.Mount{
-		Source:      rc.binPath,
-		Destination: containerBinPath(),
-		Type:        "none",
-		Options:     []string{"rbind", "ro"},
-	}
-	rc.spec.Mounts = append(rc.spec.Mounts, wfBinMount)
+
+	wfBinMounts := getBinMounts(rc.binPath)
+	rc.spec.Mounts = append(rc.spec.Mounts, wfBinMounts...)
 
 	// check if /dev/tty exists
 	rc.spec.Process.Terminal = false // default to disabled where no tty exists (e.g. github actions)


### PR DESCRIPTION
This requires following the symbolic links from the binary path. However, if a source or destination path is repeated we should not mount it twice. This de-duplication might need some tweaking.

I'm not sure if mounting an entire chain of symbolic links is a _good_ idea since you may be mounting unexpected things, but we're already doing that to some extent. For example, I can link `$HOME/gopath/bin/rio` with an absolute path link to `$HOME/repos/warpforge/plugins/rio` and it will mount the directory `$HOME/repos/warpforge/plugins` _inside_ the container to satisfy the link.

Testing this is... not easy. We would need both an `os.DirFS` and a `MapFS` with a `Stat` implementation which doesn't follow links like `Lstat`. Or we can project onto an actual filesystem and run tests from there which is a pain.

Fixes #68 .