### PR TITLE
update healthcheck

### DIFF
--- a/cmd/warpforge/internal/healthcheck/bincheck.go
+++ b/cmd/warpforge/internal/healthcheck/bincheck.go
@@ -3,6 +3,8 @@ package healthcheck
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 
 	"github.com/serum-errors/go-serum"
@@ -18,6 +20,32 @@ func (c *BinCheck) String() string {
 	return fmt.Sprintf("Binary Path Check: %q", c.Name)
 }
 
+func isExecutable(m fs.FileMode) bool {
+	return m&0111 != 0
+}
+
+func isSymlink(m fs.FileMode) bool {
+	return m&fs.ModeSymlink == fs.ModeSymlink
+}
+
+func followLink(path string) string {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return ""
+	}
+	for isSymlink(fi.Mode()) {
+		path, err = os.Readlink(path)
+		if err != nil {
+			return ""
+		}
+		fi, err = os.Lstat(path)
+		if err != nil {
+			return ""
+		}
+	}
+	return path
+}
+
 // Run checks that that an executable can be found for the given executable name
 // Errors:
 //
@@ -25,9 +53,40 @@ func (c *BinCheck) String() string {
 //    - warpforge-error-healthcheck-run-fail -- when the binary cannot be found
 func (c *BinCheck) Run(ctx context.Context) error {
 	binPath, err := config.BinPath()
-	path := filepath.Join(binPath, c.Name)
 	if err != nil {
-		return serum.Errorf(CodeRunFailure, "Could not find binary: %w", err)
+		return serum.Error(CodeRunFailure, serum.WithCause(err),
+			serum.WithMessageLiteral("Could not find binary"),
+		)
 	}
+	path := filepath.Join(binPath, c.Name)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return serum.Error(CodeRunFailure, serum.WithCause(err),
+			serum.WithMessageTemplate("Could not find binary at path {{path|q}}"),
+			serum.WithDetail("path", path),
+		)
+	}
+	mode := fi.Mode()
+	if !mode.IsRegular() {
+		return serum.Error(CodeRunFailure,
+			serum.WithMessageTemplate("file {{path|q}} is not a regular file"),
+			serum.WithDetail("path", path),
+		)
+	}
+	if !isExecutable(mode) {
+		return serum.Error(CodeRunFailure,
+			serum.WithMessageTemplate("file {{path|q}} is not executable"),
+			serum.WithDetail("path", path),
+		)
+	}
+
+	if err := executionAccess(path); err != nil {
+		return err
+	}
+
+	if fi, _ := os.Lstat(path); isSymlink(fi.Mode()) {
+		return serum.Errorf(CodeRunOkay, "symlink: %q -> %q", path, followLink(path))
+	}
+
 	return serum.Errorf(CodeRunOkay, "path: %s", path)
 }

--- a/cmd/warpforge/internal/healthcheck/kernel.go
+++ b/cmd/warpforge/internal/healthcheck/kernel.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"syscall"
 	"unicode"
 	"unsafe"
 
@@ -22,12 +21,11 @@ type KernelInfo struct{}
 //    - warpforge-error-healthcheck-run-fail -- syscall or serialization failure
 //    - warpforge-error-healthcheck-run-ambiguous -- returns kernel info
 func (k *KernelInfo) Run(ctx context.Context) error {
-	var utsname syscall.Utsname
-	err := syscall.Uname(&utsname)
+	u, err := uname()
 	if err != nil {
-		return serum.Errorf(CodeRunFailure, "uname syscall failed: %w", err)
+		return err
 	}
-	s := kernelInfoString(utsname)
+	s := kernelInfoString(u)
 	return serum.Errorf(CodeRunAmbiguous, "%s", s)
 }
 
@@ -35,7 +33,7 @@ func (k *KernelInfo) String() string {
 	return "Kernel info"
 }
 
-func kernelInfoString(u syscall.Utsname) string {
+func kernelInfoString(u *utsname) string {
 	f := strings.Repeat("\t%10s: %s\n", 6)
 	f = strings.TrimRightFunc(f, unicode.IsSpace)
 	return fmt.Sprintf("\n"+f,

--- a/cmd/warpforge/internal/healthcheck/linux.go
+++ b/cmd/warpforge/internal/healthcheck/linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package healthcheck
+
+import (
+	"syscall"
+
+	"github.com/serum-errors/go-serum"
+	"golang.org/x/sys/unix"
+)
+
+func executionAccess(path string) error {
+	err := unix.Access(path, unix.X_OK)
+	if err != nil {
+		return serum.Error(CodeRunFailure, serum.WithCause(err),
+			serum.WithMessageTemplate("warpforge does not have execution access to file {{path|q}}"),
+			serum.WithDetail("path", path),
+		)
+	}
+	return nil
+}
+
+type utsname syscall.Utsname
+
+func uname() (*utsname, error) {
+	var utsname utsname
+	err := syscall.Uname((*syscall.Utsname)(&utsname))
+	if err != nil {
+		return nil, serum.Error(CodeRunFailure, serum.WithCause(err),
+			serum.WithMessageLiteral("uname syscall failed: %w"),
+		)
+	}
+	return &utsname, nil
+}

--- a/cmd/warpforge/internal/healthcheck/notlinux.go
+++ b/cmd/warpforge/internal/healthcheck/notlinux.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package healthcheck
+
+import "github.com/serum-errors/go-serum"
+
+type utsname struct {
+	Sysname    [65]int8
+	Nodename   [65]int8
+	Release    [65]int8
+	Version    [65]int8
+	Machine    [65]int8
+	Domainname [65]int8
+}
+
+func executionAccess(path string) error {
+	return serum.Error(CodeRunAmbiguous, serum.WithMessageLiteral("Execution access detection not implemented for non-Linux systems"))
+}
+
+func uname() (*utsname, error) {
+	return nil, serum.Error(CodeRunAmbiguous, serum.WithMessageLiteral("Kernel info only for Linux systems"))
+}


### PR DESCRIPTION
Check binaries a bit more thoroughly.
Allow warpforge to compile on non-linux systems.