### PR TITLE
pass through stderr from plan generate execution

### DIFF
--- a/app/plan/generators.go
+++ b/app/plan/generators.go
@@ -19,6 +19,7 @@ var generators = map[string]func(string) ([]byte, error){
 //    - warpforge-error-generator-failed -- when the external generator fails
 func starlarkGenerator(file string) ([]byte, error) {
 	cmd := exec.Command("warplark", file)
+	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
Currently warplark will emit errors for bad starlark on stderr and
warpforge will consume that output silently. Ideally we decorate it
appropriately before emitting it blindly but this is workable.