### PR TITLE
Loosens restrictions on catalog ls results.

### DIFF
--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -258,10 +258,11 @@ func (ws *Workspace) ListCatalogs() ([]string, error) {
 	// build a list of subdirectories, each is a catalog
 	var list []string
 	for _, c := range catalogs {
-		if c.IsDir() && reCatalogName.MatchString(c.Name()) {
-			name := c.Name()
-			list = append(list, name)
+		if !reCatalogName.MatchString(c.Name()) {
+			continue
 		}
+		name := c.Name()
+		list = append(list, name)
 	}
 	return list, nil
 }

--- a/pkg/workspace/workspace_export_test.go
+++ b/pkg/workspace/workspace_export_test.go
@@ -194,3 +194,27 @@ func TestRootWorkspaceCatalogPath(t *testing.T) {
 		})
 	}
 }
+
+func TestListCatalogs(t *testing.T) {
+	rootPath := "test-workspace"
+	fsys := fstest.MapFS{
+		"test-workspace/.warpforge":                             &fstest.MapFile{Mode: 0644 | fs.ModeDir},
+		"test-workspace/.warpforge/root":                        &fstest.MapFile{Mode: 0644},
+		"test-workspace/.warpforge/catalogs":                    &fstest.MapFile{Mode: 0644 | fs.ModeDir},
+		"test-workspace/.warpforge/catalogs/somedir":            &fstest.MapFile{Mode: 0644 | fs.ModeDir},
+		"test-workspace/.warpforge/catalogs/symlink":            &fstest.MapFile{Mode: 0644 | fs.ModeSymlink},
+		"test-workspace/.warpforge/catalogs/just-a-file-counts": &fstest.MapFile{Mode: 0644},
+		"test-workspace/.warpforge/catalogs/_not_a_catalog":     &fstest.MapFile{Mode: 0644 | fs.ModeDir},
+		"test-workspace/.warpforge/catalogs/1-still-a.catalog":  &fstest.MapFile{Mode: 0644 | fs.ModeDir},
+	}
+	ws, err := workspace.OpenWorkspace(fsys, rootPath)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, ws.IsRootWorkspace(), qt.IsTrue)
+	qt.Assert(t, ws.IsHomeWorkspace(), qt.IsFalse)
+	result, err := ws.ListCatalogs()
+	qt.Check(t, err, qt.IsNil)
+	expected := []string{
+		"somedir", "symlink", "just-a-file-counts", "1-still-a.catalog",
+	}
+	qt.Check(t, result, qt.ContentEquals, expected)
+}


### PR DESCRIPTION
Removes the IsDir check for entries in the catalogs directory when returning the list of catalog names.
This allows catalogs to be symbolic links (or something else) and still work as long as it resolves properly.